### PR TITLE
Add auth tests and verify CDN

### DIFF
--- a/State-of-the-Art Website with Advanced Designs/src/main.js
+++ b/State-of-the-Art Website with Advanced Designs/src/main.js
@@ -1,6 +1,10 @@
 import React from 'https://cdn.jsdelivr.net/npm/react@18.2.0/umd/react.production.min.js'
 import ReactDOM from 'https://cdn.jsdelivr.net/npm/react-dom@18.2.0/umd/react-dom.production.min.js'
-import ReactRouterDOM from 'https://cdn.jsdelivr.net/npm/react-router-dom@6.23.0/umd/react-router-dom.production.min.js'
+// Use a stable CDN URL for React Router DOM. The previous version-specific
+// path resulted in a 404 when the requested version was not available. Using
+// the ``@6`` tag ensures we always get the latest 6.x build with the UMD
+// bundle present.
+import ReactRouterDOM from 'https://cdn.jsdelivr.net/npm/react-router-dom@6/umd/react-router-dom.production.min.js'
 import { AuthProvider, useAuth } from './AuthContext.js'
 
 const { BrowserRouter, Routes, Route, Link, Navigate, useNavigate } = ReactRouterDOM

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,66 @@
+import os
+import sys
+from pathlib import Path
+
+# Ensure the project sources are importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'State-of-the-Art Website with Advanced Designs'))
+
+import pytest
+from app import create_app
+from user import db
+
+@pytest.fixture()
+def app():
+    os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+    os.environ['JWT_SECRET_KEY'] = 'testing-secret'
+    app = create_app()
+    app.config['TESTING'] = True
+    with app.app_context():
+        db.create_all()
+    yield app
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def register_user(client, username='alice', email='alice@example.com', password='StrongPass!123'):
+    return client.post('/api/auth/register', json={
+        'username': username,
+        'email': email,
+        'password': password
+    })
+
+
+def login_user(client, username='alice', password='StrongPass!123'):
+    return client.post('/api/auth/login', json={
+        'username': username,
+        'password': password
+    })
+
+
+def test_register_requires_strong_password(client):
+    res = register_user(client, password='weak')
+    assert res.status_code == 400
+    assert 'Password' in res.get_json()['error']
+
+
+def test_register_login_logout_flow(client):
+    reg = register_user(client)
+    assert reg.status_code == 201
+
+    login = login_user(client)
+    assert login.status_code == 200
+    token = login.get_json()['access_token']
+
+    verify = client.post('/api/auth/verify-token', headers={'Authorization': f'Bearer {token}'})
+    assert verify.status_code == 200
+
+    logout = client.post('/api/auth/logout', headers={'Authorization': f'Bearer {token}'})
+    assert logout.status_code == 200
+
+    verify_again = client.post('/api/auth/verify-token', headers={'Authorization': f'Bearer {token}'})
+    assert verify_again.status_code == 401

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -1,0 +1,8 @@
+import urllib.request
+
+CDN_URL = 'https://cdn.jsdelivr.net/npm/react-router-dom@6/umd/react-router-dom.production.min.js'
+
+def test_react_router_dom_cdn_is_reachable():
+    req = urllib.request.Request(CDN_URL, method='HEAD')
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        assert resp.status == 200


### PR DESCRIPTION
## Summary
- add integration tests for auth flow with Flask
- add test to verify React Router CDN path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685152af9a90832bb5e12d7c4278241d