### PR TITLE
Fix React context and add route tests

### DIFF
--- a/State-of-the-Art Website with Advanced Designs/src/AuthContext.js
+++ b/State-of-the-Art Website with Advanced Designs/src/AuthContext.js
@@ -92,7 +92,7 @@ export function AuthProvider({ children }) {
     dispatch({ type: 'SET_LOADING', payload: false });
   };
 
-  const login = async (username, password) => {
+  const login = React.useCallback(async (username, password) => {
     dispatch({ type: 'LOGIN_START' });
     const { ok, data } = await apiRequest('/auth/login', {
       method: 'POST',
@@ -105,9 +105,9 @@ export function AuthProvider({ children }) {
     }
     dispatch({ type: 'LOGIN_FAILURE', payload: data.error });
     return { success: false, error: data.error };
-  };
+  }, []);
 
-  const register = async (username, email, password) => {
+  const register = React.useCallback(async (username, email, password) => {
     dispatch({ type: 'LOGIN_START' });
     const { ok, data } = await apiRequest('/auth/register', {
       method: 'POST',
@@ -118,15 +118,15 @@ export function AuthProvider({ children }) {
     }
     dispatch({ type: 'LOGIN_FAILURE', payload: data.error });
     return { success: false, error: data.error };
-  };
+  }, []);
 
-  const logout = async () => {
+  const logout = React.useCallback(async () => {
     await apiRequest('/auth/logout', { method: 'POST' });
     localStorage.removeItem('auth_token');
     dispatch({ type: 'LOGOUT' });
-  };
+  }, []);
 
-  const changePassword = async (currentPassword, newPassword) => {
+  const changePassword = React.useCallback(async (currentPassword, newPassword) => {
     const { ok, data } = await apiRequest('/auth/change-password', {
       method: 'POST',
       body: JSON.stringify({
@@ -138,25 +138,28 @@ export function AuthProvider({ children }) {
       return { success: true, data };
     }
     return { success: false, error: data.error };
-  };
+  }, []);
 
-  const clearError = () => {
+  const clearError = React.useCallback(() => {
     dispatch({ type: 'CLEAR_ERROR' });
-  };
+  }, []);
 
-  const value = {
-    ...state,
-    login,
-    register,
-    logout,
-    changePassword,
-    clearError
-  };
+  const value = React.useMemo(
+    () => ({
+      ...state,
+      login,
+      register,
+      logout,
+      changePassword,
+      clearError
+    }),
+    [state, login, register, logout, changePassword, clearError]
+  );
 
-  return (
-    <AuthContext.Provider value={value}>
-      {children}
-    </AuthContext.Provider>
+  return React.createElement(
+    AuthContext.Provider,
+    { value },
+    children
   );
 }
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,45 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'State-of-the-Art Website with Advanced Designs'))
+
+import pytest
+from app import create_app
+from user import db
+
+@pytest.fixture()
+def app():
+    os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+    os.environ['JWT_SECRET_KEY'] = 'testing-secret'
+    app = create_app()
+    app.config['TESTING'] = True
+    with app.app_context():
+        db.create_all()
+    yield app
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def test_index_served(client):
+    res = client.get('/')
+    assert res.status_code == 200
+    assert b'SecureVault' in res.data
+
+
+def test_main_js_served(client):
+    res = client.get('/src/main.js')
+    assert res.status_code == 200
+    assert b'import React' in res.data
+
+
+def test_auth_context_no_jsx(client):
+    res = client.get('/src/AuthContext.js')
+    assert res.status_code == 200
+    assert b'<AuthContext.Provider' not in res.data
+    assert b'React.createElement' in res.data


### PR DESCRIPTION
## Summary
- rewrite AuthProvider functions with `useCallback` and memoize context value
- add integration tests to ensure server serves frontend assets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68515485a0a0832b8d7035fd80475ea7