### PR TITLE
Use ESM React CDN imports

### DIFF
--- a/State-of-the-Art Website with Advanced Designs/src/AuthContext.js
+++ b/State-of-the-Art Website with Advanced Designs/src/AuthContext.js
@@ -1,4 +1,9 @@
-import React, { createContext, useContext, useReducer, useEffect } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useReducer,
+  useEffect
+} from 'https://cdn.jsdelivr.net/npm/react@18.2.0/+esm'
 
 const AuthContext = createContext();
 

--- a/State-of-the-Art Website with Advanced Designs/src/main.js
+++ b/State-of-the-Art Website with Advanced Designs/src/main.js
@@ -1,10 +1,10 @@
-import React from 'https://cdn.jsdelivr.net/npm/react@18.2.0/umd/react.production.min.js'
-import ReactDOM from 'https://cdn.jsdelivr.net/npm/react-dom@18.2.0/umd/react-dom.production.min.js'
+import React from 'https://cdn.jsdelivr.net/npm/react@18.2.0/+esm'
+import ReactDOM from 'https://cdn.jsdelivr.net/npm/react-dom@18.2.0/+esm'
 // Use a stable CDN URL for React Router DOM. The previous version-specific
 // path resulted in a 404 when the requested version was not available. Using
 // the ``@6`` tag ensures we always get the latest 6.x build with the UMD
 // bundle present.
-import ReactRouterDOM from 'https://cdn.jsdelivr.net/npm/react-router-dom@6/umd/react-router-dom.production.min.js'
+import ReactRouterDOM from 'https://cdn.jsdelivr.net/npm/react-router-dom@6/+esm'
 import { AuthProvider, useAuth } from './AuthContext.js'
 
 const { BrowserRouter, Routes, Route, Link, Navigate, useNavigate } = ReactRouterDOM


### PR DESCRIPTION
## Summary
- switch React, ReactDOM, and React Router DOM CDN imports to their ESM versions

## Testing
- `pip install -q -r State-of-the-Art Website with Advanced Designs/requirements.txt`
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851563cd128832b9cf861b375df0dca