### PR TITLE
Fix ReactDOM import

### DIFF
--- a/State-of-the-Art Website with Advanced Designs/src/main.js
+++ b/State-of-the-Art Website with Advanced Designs/src/main.js
@@ -1,5 +1,5 @@
 import React from 'https://cdn.jsdelivr.net/npm/react@18.2.0/+esm'
-import ReactDOM from 'https://cdn.jsdelivr.net/npm/react-dom@18.2.0/+esm'
+import { createRoot } from 'https://cdn.jsdelivr.net/npm/react-dom@18.2.0/client/+esm'
 // Use a stable CDN URL for React Router DOM. The previous version-specific
 // path resulted in a 404 when the requested version was not available. Using
 // the ``@6`` tag ensures we always get the latest 6.x build with the UMD
@@ -142,6 +142,6 @@ function App() {
 }
 
 const rootEl = document.getElementById('root')
-ReactDOM.createRoot(rootEl).render(
+createRoot(rootEl).render(
   e(AuthProvider, null, e(App))
 )


### PR DESCRIPTION
## Summary
- fix ReactDOM import path to use the `client` entry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851596b8978832ba6c262152cfa1c7e