### PR TITLE
Fix transition fade-out effect

### DIFF
--- a/script.js
+++ b/script.js
@@ -477,4 +477,11 @@ lazyImages.forEach(img => imageObserver.observe(img));
 window.addEventListener('beforeunload', () => {
   document.body.style.opacity = '0';
 });
+
+const resetOpacity = () => {
+  document.body.style.opacity = '1';
+};
+
+window.addEventListener('load', resetOpacity);
+window.addEventListener('pageshow', resetOpacity);
   

--- a/styles.css
+++ b/styles.css
@@ -24,7 +24,8 @@ body {
   background: var(--bg-color);
   color: var(--text-color);
   line-height: 1.6;
-  transition: background 0.3s ease, color 0.3s ease;
+  opacity: 1;
+  transition: background 0.3s ease, color 0.3s ease, opacity 0.3s ease;
 }
 
 .no-scroll {


### PR DESCRIPTION
## Summary
- ensure body fades in correctly by resetting opacity on page load
- extend `body` style to include opacity transition
- reset opacity when returning via browser bfcache

## Testing
- `npx eslint .`
- `npx stylelint styles.css --formatter verbose`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685266f06d8c832ba0cbeccffeba3a56