### PR TITLE
Add search button with openSearch handler

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,9 @@
         <li><a href="#gallery">Gallery</a></li>
         <li><a href="#contact">Contact</a></li>
       </ul>
+      <button class="search-toggle" aria-label="Open search" aria-haspopup="dialog" aria-controls="searchOverlay" aria-expanded="false">
+        <i class="fas fa-search"></i>
+      </button>
       <button class="nav-toggle" aria-label="Toggle navigation">
         <span>&nbsp;</span>
         <span>&nbsp;</span>
@@ -217,8 +220,9 @@
     </div>
   </footer>
 
-  <div id="searchOverlay" class="search-overlay" aria-hidden="true">
+  <div id="searchOverlay" class="search-overlay" aria-hidden="true" role="dialog">
     <div class="search-box">
+      <button class="search-close" aria-label="Close search">&times;</button>
       <input type="text" id="searchInput" placeholder="Search..." aria-label="Search" />
       <ul id="searchResults" class="search-results"></ul>
     </div>

--- a/script.js
+++ b/script.js
@@ -164,10 +164,15 @@ document.addEventListener('DOMContentLoaded', () => {
   const searchInput = document.getElementById('searchInput');
   const searchResults = document.getElementById('searchResults');
   let searchIndex = [];
+  const searchButton = document.querySelector('.search-toggle');
+  const searchClose = document.querySelector('.search-close');
 
   function openSearch() {
     searchOverlay.classList.add('active');
     searchOverlay.setAttribute('aria-hidden', 'false');
+    if (searchButton) {
+      searchButton.setAttribute('aria-expanded', 'true');
+    }
     searchInput.value = '';
     searchResults.innerHTML = '';
     searchInput.focus();
@@ -177,7 +182,17 @@ document.addEventListener('DOMContentLoaded', () => {
   function closeSearch() {
     searchOverlay.classList.remove('active');
     searchOverlay.setAttribute('aria-hidden', 'true');
+    if (searchButton) {
+      searchButton.setAttribute('aria-expanded', 'false');
+    }
     document.body.classList.remove('no-scroll');
+  }
+
+  if (searchButton) {
+    searchButton.addEventListener('click', openSearch);
+  }
+  if (searchClose) {
+    searchClose.addEventListener('click', closeSearch);
   }
 
   const notificationToggle = document.querySelector('.notification-toggle');

--- a/styles.css
+++ b/styles.css
@@ -96,6 +96,22 @@ body {
   width: 100%;
 }
 
+/* Search Toggle */
+.search-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-color);
+  font-size: 1.2rem;
+  padding: 0.5rem;
+  margin-left: 1rem;
+  transition: color 0.3s ease;
+}
+
+.search-toggle:hover {
+  color: var(--accent-color);
+}
+
 .nav-toggle {
   display: none;
   flex-direction: column;
@@ -1007,6 +1023,23 @@ body.dark-mode .notification {
   padding: 1rem;
   border-radius: 8px;
   box-shadow: 0 4px 20px rgb(0 0 0 / 20%);
+  position: relative;
+}
+
+.search-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  color: var(--text-light);
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.search-close:hover {
+  color: var(--accent-color);
 }
 
 body.dark-mode .search-box {
@@ -1069,6 +1102,7 @@ body.dark-mode .search-box {
 @media print {
   .theme-toggle,
   .nav-toggle,
+  .search-toggle,
   .scroll-top,
   .notification-container {
     display: none;


### PR DESCRIPTION
## Summary
- add a search toggle button to the navbar
- trigger openSearch on search toggle click
- style the search button in the navigation
- add search overlay close button
- enhance accessibility for the search overlay

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68527455a2cc832bb47953f7370e1f21