### PR TITLE
Fix animejs import for static server

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ Ensure you have Node.js installed or run `pip install sass` to enable the
 fallback compiler.
 
 ```bash
+npm install   # install dependencies such as Anime.js
 python security.py
 ```
 
-This starts a local web server and automatically opens the site in your browser. Using a server avoids CORS restrictions that occur when opening `index.html` directly from the file system.
+This starts a local web server and automatically opens the site in your browser. Using a server avoids CORS restrictions that occur when opening `index.html` directly from the file system. Running `npm install` ensures the required modules are available when the page loads.
 
 Alternatively you can use the development server provided by Vite (requires Node.js and dependencies):
 

--- a/hero-animations.js
+++ b/hero-animations.js
@@ -1,4 +1,6 @@
-import anime from 'animejs/lib/anime.es.js';
+// Import Anime.js from the local node_modules directory so the script works
+// when served by a simple HTTP server without a bundler.
+import anime from './node_modules/animejs/lib/anime.es.js';
 
 export function initHeroAnimations() {
   if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {


### PR DESCRIPTION
## Summary
- fix hero animation import path for static server
- document running npm install before running python server

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68529ebcfedc832b83f6ed3074c66ef5