### PR TITLE
Update docs for SCSS compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,13 @@ is not installed the server will attempt to install it with `pip`.
 **Node.js is strongly recommended.** The Python fallback requires a working C/C++
 compiler and may fail on some platforms (for example Python 3.13 on Windows does
 not currently have prebuilt wheels). Installing [Node.js](https://nodejs.org)
-ensures SCSS compilation works out of the box.
+ensures SCSS compilation works out of the box. After installing Node.js,
+install the `sass` compiler globally so the server can compile SCSS without
+falling back to Python:
+
+```bash
+npm install -g sass
+```
 
 ```bash
 npm install   # install dependencies such as Anime.js


### PR DESCRIPTION
## Summary
- add steps for global `sass` install after Node.js setup

## Testing
- `npm install`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6852a1411514832ba7c016f9ce160e51