### PR TITLE
Fix anime import path and add import map

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ npm install   # install dependencies such as Anime.js
 python security.py
 ```
 
+If dependencies are missing, scripts like the hero animations may fail to load
+(resulting in 404 errors for files under `node_modules`). Running `npm install`
+ensures the necessary modules are available when the page loads.
+
 This starts a local web server and automatically opens the site in your browser. Using a server avoids CORS restrictions that occur when opening `index.html` directly from the file system. Running `npm install` ensures the required modules are available when the page loads.
 
 Alternatively you can use the development server provided by Vite (requires Node.js and dependencies):

--- a/hero-animations.js
+++ b/hero-animations.js
@@ -1,22 +1,20 @@
 // Import Anime.js from the local node_modules directory so the script works
 // when served by a simple HTTP server without a bundler.
-import anime from './node_modules/animejs/lib/anime.es.js';
+import { animate, stagger } from 'animejs';
 
 export function initHeroAnimations() {
   if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
     return;
   }
 
-  anime({
-    targets: '.hero-title',
+  animate('.hero-title', {
     opacity: [0, 1],
     translateY: [40, 0],
     duration: 700,
     easing: 'easeOutCubic',
   });
 
-  anime({
-    targets: '.hero-subtitle',
+  animate('.hero-subtitle', {
     opacity: [0, 1],
     translateY: [40, 0],
     duration: 700,
@@ -24,17 +22,15 @@ export function initHeroAnimations() {
     easing: 'easeOutCubic',
   });
 
-  anime({
-    targets: '.hero-buttons .btn',
+  animate('.hero-buttons .btn', {
     opacity: [0, 1],
     translateY: [40, 0],
-    delay: anime.stagger(100, { start: 400 }),
+    delay: stagger(100, { start: 400 }),
     duration: 600,
     easing: 'easeOutCubic',
   });
 
-  anime({
-    targets: '.shield-animation',
+  animate('.shield-animation', {
     opacity: [0, 1],
     scale: [0.8, 1],
     duration: 800,

--- a/index.html
+++ b/index.html
@@ -8,6 +8,13 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link rel="stylesheet" href="main.css">
   <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAQAAAC1+jfqAAAAI0lEQVR42mNkYGD4z8DAwMDAgAn8j8DAYTAIMwgwGhAIAAOWcBShK5T2wAAAAASUVORK5CYII=" />
+  <script type="importmap">
+    {
+      "imports": {
+        "animejs": "./node_modules/animejs/lib/anime.esm.js"
+      }
+    }
+  </script>
 </head>
 <body class="no-scroll">
   <div id="preloader">


### PR DESCRIPTION
## Summary
- import anime properly as `animate` & `stagger`
- include an importmap so browsers can load Anime.js when served without a bundler
- note in README that missing dependencies cause 404 errors

## Testing
- `npm test`
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6852a1b802cc832bb05d53110c07a8dc