### PR TITLE
Add diagnostics dashboard

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -1,0 +1,52 @@
+export function initDashboard() {
+  const logList = document.getElementById('dashboardLogs');
+  const fetchTree = document.getElementById('fetchLogs');
+  if (!logList || !fetchTree) return;
+
+  const appendLog = (type, message) => {
+    const li = document.createElement('li');
+    li.className = `log-${type}`;
+    li.textContent = message;
+    logList.appendChild(li);
+  };
+
+  const origError = console.error;
+  console.error = (...args) => {
+    appendLog('error', args.join(' '));
+    origError.apply(console, args);
+  };
+
+  const origWarn = console.warn;
+  console.warn = (...args) => {
+    appendLog('warning', args.join(' '));
+    origWarn.apply(console, args);
+  };
+
+  const origFetch = window.fetch;
+  window.fetch = async (...args) => {
+    const url = args[0];
+    const node = document.createElement('li');
+    node.innerHTML = `<span class="fetch-url">${url}</span>`;
+    const children = document.createElement('ul');
+    node.appendChild(children);
+    fetchTree.appendChild(node);
+    try {
+      const res = await origFetch(...args);
+      const statusItem = document.createElement('li');
+      statusItem.textContent = `Status: ${res.status}`;
+      statusItem.className = res.ok ? 'log-success' : 'log-error';
+      children.appendChild(statusItem);
+      if (!res.ok) {
+        appendLog('error', `Fetch to ${url} failed with status ${res.status}`);
+      }
+      return res;
+    } catch (err) {
+      const errItem = document.createElement('li');
+      errItem.textContent = err.toString();
+      errItem.className = 'log-error';
+      children.appendChild(errItem);
+      appendLog('error', `Fetch to ${url} failed: ${err.message}`);
+      throw err;
+    }
+  };
+}

--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
         <li><a href="#services">Services</a></li>
         <li><a href="#about">About</a></li>
         <li><a href="#gallery">Gallery</a></li>
+        <li><a href="#dashboard">Dashboard</a></li>
         <li><a href="#contact">Contact</a></li>
       </ul>
       <button class="search-toggle" aria-label="Open search" aria-haspopup="dialog" aria-controls="searchOverlay" aria-expanded="false">
@@ -184,6 +185,23 @@
     </div>
   </div>
 </section>
+
+  <section id="dashboard" class="dashboard">
+    <div class="container">
+      <h2 class="section-title">Diagnostics Dashboard</h2>
+      <p class="dashboard-intro">Monitor console errors and network connections in real time.</p>
+      <div class="dashboard-grid">
+        <div class="dashboard-panel">
+          <h3>Console Logs</h3>
+          <ul id="dashboardLogs" class="log-list"></ul>
+        </div>
+        <div class="dashboard-panel">
+          <h3>Network Activity</h3>
+          <ul id="fetchLogs" class="tree-list"></ul>
+        </div>
+      </div>
+    </div>
+  </section>
   <section id="contact" class="contact">
     <div class="container">
       <h2 class="section-title">Get In Touch</h2>

--- a/main.css
+++ b/main.css
@@ -864,6 +864,61 @@ body.dark-mode .demo-card {
   list-style: disc;
 }
 
+/* Dashboard Section */
+.dashboard {
+  padding: 5rem 0;
+  background: var(--bg-color);
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 2rem;
+  margin-top: 2rem;
+}
+
+.dashboard-panel {
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 10px;
+  box-shadow: var(--card-shadow);
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+body.dark-mode .dashboard-panel {
+  background: #1e1e1e;
+}
+
+.log-list,
+.tree-list {
+  list-style: none;
+  padding-left: 0;
+}
+
+.tree-list ul {
+  margin-left: 1rem;
+  border-left: 2px solid var(--border-color);
+  padding-left: 0.5rem;
+}
+
+.log-error {
+  color: var(--danger-color);
+}
+
+.log-warning {
+  color: var(--warning-color);
+}
+
+.log-success {
+  color: var(--success-color);
+}
+
+.fetch-url {
+  font-weight: 600;
+  color: var(--primary-color);
+}
+
 /* Contact Section */
 .contact {
   padding: 5rem 0;

--- a/main.js
+++ b/main.js
@@ -4,11 +4,13 @@ import { NotificationSystem, initNotificationToggle } from './notifications.js';
 import { setupSecurityDemo, securityFeatures } from './security-demo.js';
 import { validateForm } from './utils.js';
 import { initHeroAnimations } from './hero-animations.js';
+import { initDashboard } from './dashboard.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
   initTheme();
   const navMenu = initNavigation();
   await initHeroAnimations();
+  initDashboard();
 
   const counters = document.querySelectorAll('.stat-number');
   const speed = 200;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -892,6 +892,61 @@ body.dark-mode .demo-card {
   list-style: disc;
 }
 
+/* Dashboard Section */
+.dashboard {
+  padding: 5rem 0;
+  background: var(--bg-color);
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 2rem;
+  margin-top: 2rem;
+}
+
+.dashboard-panel {
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 10px;
+  box-shadow: var(--card-shadow);
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+body.dark-mode .dashboard-panel {
+  background: #1e1e1e;
+}
+
+.log-list,
+.tree-list {
+  list-style: none;
+  padding-left: 0;
+}
+
+.tree-list ul {
+  margin-left: 1rem;
+  border-left: 2px solid var(--border-color);
+  padding-left: 0.5rem;
+}
+
+.log-error {
+  color: var(--danger-color);
+}
+
+.log-warning {
+  color: var(--warning-color);
+}
+
+.log-success {
+  color: var(--success-color);
+}
+
+.fetch-url {
+  font-weight: 600;
+  color: var(--primary-color);
+}
+
 /* Contact Section */
 .contact {
   padding: 5rem 0;

--- a/tests/dashboard.test.js
+++ b/tests/dashboard.test.js
@@ -1,0 +1,32 @@
+import { jest } from '@jest/globals';
+import { initDashboard } from '../dashboard.js';
+
+describe('initDashboard', () => {
+  test('captures console errors', () => {
+    document.body.innerHTML = `
+      <ul id="dashboardLogs" class="log-list"></ul>
+      <ul id="fetchLogs" class="tree-list"></ul>
+    `;
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    initDashboard();
+    console.error('boom');
+    errorSpy.mockRestore();
+    const li = document.querySelector('.log-error');
+    expect(li).not.toBeNull();
+    expect(li.textContent).toMatch('boom');
+  });
+
+  test('logs failed fetch attempts', async () => {
+    document.body.innerHTML = `
+      <ul id="dashboardLogs" class="log-list"></ul>
+      <ul id="fetchLogs" class="tree-list"></ul>
+    `;
+    global.fetch = jest.fn(() => Promise.reject(new Error('fail')));
+    initDashboard();
+    await expect(fetch('http://x')).rejects.toThrow('fail');
+    const tree = document.querySelector('.tree-list li');
+    expect(tree).not.toBeNull();
+    const log = document.querySelector('.log-error');
+    expect(log).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add diagnostics dashboard with console and network logs
- integrate dashboard in main.js
- style the dashboard in SCSS and CSS
- highlight fetch URLs for readability
- add unit tests for dashboard functionality

## Testing
- `npm test --silent`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6852b137bd3c832bb813e68abfc35320