### PR TITLE
Improve dashboard UI and fix anime loading

### DIFF
--- a/dashboard-page.js
+++ b/dashboard-page.js
@@ -1,0 +1,45 @@
+import { initTheme, initNavigation } from './theme.js';
+import { initSearch } from './search.js';
+import { NotificationSystem, initNotificationToggle } from './notifications.js';
+import { initDashboard } from './dashboard.js';
+
+function setupChart() {
+  const ctx = document.getElementById('networkChart');
+  if (!ctx || !window.Chart) return null;
+  return new Chart(ctx, {
+    type: 'doughnut',
+    data: {
+      labels: ['Success', 'Failed'],
+      datasets: [{ data: [0, 0], backgroundColor: ['#22c55e', '#ef4444'] }],
+    },
+    options: { responsive: true, maintainAspectRatio: false },
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initTheme();
+  const navMenu = initNavigation();
+  initSearch(navMenu);
+
+  const notifications = new NotificationSystem();
+  initNotificationToggle(notifications);
+
+  const chart = setupChart();
+  const stats = {
+    errorsEl: document.getElementById('errorsCount'),
+    warningsEl: document.getElementById('warningsCount'),
+    requestsEl: document.getElementById('requestsCount'),
+  };
+
+  initDashboard({
+    onStats({ errors, warnings, requests, successes, failures }) {
+      if (stats.errorsEl) stats.errorsEl.textContent = errors;
+      if (stats.warningsEl) stats.warningsEl.textContent = warnings;
+      if (stats.requestsEl) stats.requestsEl.textContent = requests;
+      if (chart) {
+        chart.data.datasets[0].data = [successes, failures];
+        chart.update();
+      }
+    },
+  });
+});

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SecureGuard Dashboard</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="stylesheet" href="main.css">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>
+  <script type="importmap">
+    {
+      "imports": {
+        "animejs": "./node_modules/animejs/lib/anime.esm.js"
+      }
+    }
+  </script>
+</head>
+<body>
+  <button class="theme-toggle" aria-label="Toggle theme">
+    <i class="fas fa-moon"></i>
+  </button>
+  <button class="notification-toggle" aria-label="Toggle notifications" aria-pressed="true">
+    <i class="fas fa-bell"></i>
+  </button>
+
+  <nav class="navbar">
+    <div class="nav-container">
+      <div class="logo">
+        <i class="fas fa-shield-alt"></i>
+        <span>SecureGuard</span>
+      </div>
+      <ul class="nav-menu">
+        <li><a href="index.html#home">Home</a></li>
+        <li><a href="index.html#features">Features</a></li>
+        <li><a href="index.html#services">Services</a></li>
+        <li><a href="dashboard.html">Dashboard</a></li>
+      </ul>
+      <button class="search-toggle" aria-label="Open search" aria-haspopup="dialog" aria-controls="searchOverlay" aria-expanded="false">
+        <i class="fas fa-search"></i>
+      </button>
+      <button class="nav-toggle" aria-label="Toggle navigation">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+    </div>
+  </nav>
+
+  <section class="dashboard-page">
+    <div class="container">
+      <h1 class="section-title">Diagnostics Dashboard</h1>
+      <div class="dashboard-stats">
+        <div class="stat"><span id="errorsCount">0</span><small>Errors</small></div>
+        <div class="stat"><span id="warningsCount">0</span><small>Warnings</small></div>
+        <div class="stat"><span id="requestsCount">0</span><small>Requests</small></div>
+      </div>
+      <div class="chart-container">
+        <canvas id="networkChart" width="400" height="200"></canvas>
+      </div>
+      <div class="dashboard-grid">
+        <div class="dashboard-panel">
+          <h3>Console Logs</h3>
+          <ul id="dashboardLogs" class="log-list"></ul>
+        </div>
+        <div class="dashboard-panel">
+          <h3>Network Activity</h3>
+          <ul id="fetchLogs" class="tree-list"></ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <footer>
+    <div class="footer-bottom">
+      <p>&copy; 2025 SecureGuard. All rights reserved.</p>
+    </div>
+  </footer>
+
+  <div id="searchOverlay" class="search-overlay" aria-hidden="true" role="dialog">
+    <div class="search-box">
+      <button class="search-close" aria-label="Close search">&times;</button>
+      <input type="text" id="searchInput" placeholder="Search..." aria-label="Search" />
+      <ul id="searchResults" class="search-results"></ul>
+    </div>
+  </div>
+
+  <script type="module" src="dashboard-page.js"></script>
+</body>
+</html>

--- a/dashboard.js
+++ b/dashboard.js
@@ -1,7 +1,19 @@
-export function initDashboard() {
+export function initDashboard(options = {}) {
   const logList = document.getElementById('dashboardLogs');
   const fetchTree = document.getElementById('fetchLogs');
   if (!logList || !fetchTree) return;
+
+  let errors = 0;
+  let warnings = 0;
+  let requests = 0;
+  let successes = 0;
+  let failures = 0;
+
+  const report = () => {
+    if (typeof options.onStats === 'function') {
+      options.onStats({ errors, warnings, requests, successes, failures });
+    }
+  };
 
   const appendLog = (type, message) => {
     const li = document.createElement('li');
@@ -13,18 +25,23 @@ export function initDashboard() {
   const origError = console.error;
   console.error = (...args) => {
     appendLog('error', args.join(' '));
+    errors += 1;
+    report();
     origError.apply(console, args);
   };
 
   const origWarn = console.warn;
   console.warn = (...args) => {
     appendLog('warning', args.join(' '));
+    warnings += 1;
+    report();
     origWarn.apply(console, args);
   };
 
   const origFetch = window.fetch;
   window.fetch = async (...args) => {
     const url = args[0];
+    requests += 1;
     const node = document.createElement('li');
     node.innerHTML = `<span class="fetch-url">${url}</span>`;
     const children = document.createElement('ul');
@@ -37,8 +54,12 @@ export function initDashboard() {
       statusItem.className = res.ok ? 'log-success' : 'log-error';
       children.appendChild(statusItem);
       if (!res.ok) {
+        failures += 1;
         appendLog('error', `Fetch to ${url} failed with status ${res.status}`);
+      } else {
+        successes += 1;
       }
+      report();
       return res;
     } catch (err) {
       const errItem = document.createElement('li');
@@ -46,6 +67,8 @@ export function initDashboard() {
       errItem.className = 'log-error';
       children.appendChild(errItem);
       appendLog('error', `Fetch to ${url} failed: ${err.message}`);
+      failures += 1;
+      report();
       throw err;
     }
   };

--- a/hero-animations.js
+++ b/hero-animations.js
@@ -4,13 +4,16 @@ let animeModule;
 
 async function loadAnime() {
   try {
-    animeModule = await import('animejs');
+    const res = await fetch('./node_modules/animejs/lib/anime.esm.js', { method: 'HEAD' });
+    if (res.ok) {
+      animeModule = await import('animejs');
+      return;
+    }
+    throw new Error('local file missing');
   } catch (err) {
     console.warn('Local Anime.js not found, loading from CDN...', err);
     try {
-      animeModule = await import(
-        'https://cdn.jsdelivr.net/npm/animejs@4.0.2/lib/anime.esm.min.js'
-      );
+      animeModule = await import('https://cdn.jsdelivr.net/npm/animejs@4.0.2/lib/anime.esm.min.js');
     } catch (cdnErr) {
       console.error('Failed to load Anime.js from CDN', cdnErr);
       animeModule = null;

--- a/main.css
+++ b/main.css
@@ -39,8 +39,7 @@ body {
   top: 0;
   width: 100%;
   background: rgba(255, 255, 255, 0.6);
-  -webkit-backdrop-filter: blur(20px);
-          backdrop-filter: blur(20px);
+  backdrop-filter: blur(20px);
   border-bottom: 1px solid rgba(255, 255, 255, 0.4);
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
   z-index: 1000;
@@ -328,8 +327,7 @@ body {
 
 .feature-card {
   background: rgba(255, 255, 255, 0.7);
-  -webkit-backdrop-filter: blur(10px);
-          backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
   border: 1px solid rgba(255, 255, 255, 0.4);
   padding: 2rem;
   border-radius: 12px;
@@ -422,8 +420,7 @@ body {
   margin-bottom: 3rem;
   padding: 2rem;
   background: rgba(255, 255, 255, 0.7);
-  -webkit-backdrop-filter: blur(10px);
-          backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
   border: 1px solid rgba(255, 255, 255, 0.4);
   border-radius: 12px;
   box-shadow: var(--card-shadow);
@@ -919,6 +916,31 @@ body.dark-mode .dashboard-panel {
   color: var(--primary-color);
 }
 
+.dashboard-stats {
+  display: flex;
+  justify-content: space-around;
+  margin-bottom: 2rem;
+  text-align: center;
+}
+
+.dashboard-stats .stat {
+  display: flex;
+  flex-direction: column;
+}
+
+.dashboard-stats .stat span {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--primary-color);
+}
+
+.chart-container {
+  width: 100%;
+  max-width: 600px;
+  height: 300px;
+  margin: 0 auto 2rem;
+}
+
 /* Contact Section */
 .contact {
   padding: 5rem 0;
@@ -955,8 +977,7 @@ body.dark-mode .dashboard-panel {
   border-radius: 5px;
   font-size: 1rem;
   background: rgba(255, 255, 255, 0.6);
-  -webkit-backdrop-filter: blur(5px);
-          backdrop-filter: blur(5px);
+  backdrop-filter: blur(5px);
   transition: border-color 0.3s ease;
 }
 

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -947,6 +947,31 @@ body.dark-mode .dashboard-panel {
   color: var(--primary-color);
 }
 
+.dashboard-stats {
+  display: flex;
+  justify-content: space-around;
+  margin-bottom: 2rem;
+  text-align: center;
+}
+
+.dashboard-stats .stat {
+  display: flex;
+  flex-direction: column;
+}
+
+.dashboard-stats .stat span {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--primary-color);
+}
+
+.chart-container {
+  width: 100%;
+  max-width: 600px;
+  height: 300px;
+  margin: 0 auto 2rem;
+}
+
 /* Contact Section */
 .contact {
   padding: 5rem 0;


### PR DESCRIPTION
## Summary
- add a dedicated `dashboard.html` page with diagnostics
- provide `dashboard-page.js` script that updates dashboard stats and renders a chart
- extend `dashboard.js` to track request/console statistics
- avoid anime.js import error by checking for the local file before loading from CDN
- style the new dashboard elements

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852b422dfe8832bb3e250c6e022d990