### PR TITLE
Fix Anime.js 404 by auto-installing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ python security.py
 ```
 
 If dependencies are missing, scripts like the hero animations may fail to load
-(resulting in 404 errors for files under `node_modules`). Running `npm install`
-ensures the necessary modules are available when the page loads.
+(resulting in 404 errors for files under `node_modules`). The `security.py`
+server automatically attempts to run `npm install` when these packages are not
+found. Running `npm install` manually beforehand is still recommended to speed
+up startup and ensure the necessary modules are available when the page loads.
 
 This starts a local web server and automatically opens the site in your browser. Using a server avoids CORS restrictions that occur when opening `index.html` directly from the file system. Running `npm install` ensures the required modules are available when the page loads.
 

--- a/security.py
+++ b/security.py
@@ -20,6 +20,27 @@ except Exception:  # ImportError or other issues
 
 ROOT_DIR = Path(__file__).parent
 
+
+def _ensure_node_deps() -> None:
+    """Install Node dependencies if ``animejs`` is missing."""
+    anime_path = ROOT_DIR / "node_modules" / "animejs" / "lib" / "anime.esm.js"
+    if anime_path.exists():
+        return
+
+    npm_cmd = shutil.which("npm") or shutil.which("npm.cmd")
+    if not npm_cmd:
+        print(
+            "Anime.js dependency missing and npm not found. "
+            "Install Node.js and run 'npm install' manually."
+        )
+        return
+
+    print("Node dependencies missing; running 'npm install'...")
+    try:
+        subprocess.run([npm_cmd, "install"], check=True)
+    except subprocess.CalledProcessError as exc:
+        print("Failed to install npm dependencies:", exc)
+
 def _install_python_sass() -> bool:
     """Attempt to install the python ``sass`` module via pip without building."""
     try:
@@ -112,6 +133,7 @@ def _find_free_port(start: int = 8000) -> int:
 
 
 def main() -> None:
+    _ensure_node_deps()
     compile_scss()
     port = _find_free_port()
     handler = partial(SimpleHTTPRequestHandler, directory=ROOT_DIR)


### PR DESCRIPTION
## Summary
- automatically install node dependencies if Anime.js is missing
- document this automatic install step in README

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6852b8d06308832bb5811614d8e14482