### PR TITLE
Separate dashboard page

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -64,6 +64,12 @@
             <h3>Console Logs</h3>
             <div class="dashboard-controls">
               <label><input type="checkbox" id="autoScroll" checked /> Auto-scroll</label>
+              <select id="logFilter" class="log-filter">
+                <option value="all">All</option>
+                <option value="error">Errors</option>
+                <option value="warning">Warnings</option>
+                <option value="info">Info</option>
+              </select>
               <button id="clearLogs" class="btn btn-small btn-secondary">Clear</button>
             </div>
           </div>

--- a/dashboard.js
+++ b/dashboard.js
@@ -12,11 +12,24 @@ export function initDashboard(options = {}) {
   const autoScrollBox =
     document.querySelector(options.autoScrollEl || '#autoScroll');
   const clearButton = document.querySelector(options.clearBtnEl || '#clearLogs');
+  const filterSelect = document.querySelector(options.filterSelectEl || '#logFilter');
+
+  let logFilter = filterSelect ? filterSelect.value : 'all';
 
   let autoScroll = !autoScrollBox || autoScrollBox.checked;
   if (autoScrollBox) {
     autoScrollBox.addEventListener('change', () => {
       autoScroll = autoScrollBox.checked;
+    });
+  }
+
+  if (filterSelect) {
+    filterSelect.addEventListener('change', () => {
+      logFilter = filterSelect.value;
+      Array.from(logList.children).forEach((li) => {
+        li.style.display =
+          logFilter === 'all' || li.dataset.type === logFilter ? '' : 'none';
+      });
     });
   }
 
@@ -42,8 +55,12 @@ export function initDashboard(options = {}) {
   const appendLog = (type, message) => {
     const li = document.createElement('li');
     li.className = `log-${type}`;
+    li.dataset.type = type;
     const timestamp = new Date().toLocaleTimeString();
     li.innerHTML = `<span class="log-timestamp">${timestamp}</span> ${message}`;
+    if (logFilter !== 'all' && logFilter !== type) {
+      li.style.display = 'none';
+    }
     logList.appendChild(li);
     if (autoScroll) {
       logList.scrollTop = logList.scrollHeight;

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
         <li><a href="#services">Services</a></li>
         <li><a href="#about">About</a></li>
         <li><a href="#gallery">Gallery</a></li>
-        <li><a href="#dashboard">Dashboard</a></li>
+        <li><a href="dashboard.html">Dashboard</a></li>
         <li><a href="#contact">Contact</a></li>
       </ul>
       <button class="search-toggle" aria-label="Open search" aria-haspopup="dialog" aria-controls="searchOverlay" aria-expanded="false">
@@ -186,28 +186,6 @@
   </div>
 </section>
 
-  <section id="dashboard" class="dashboard">
-    <div class="container">
-      <h2 class="section-title">Diagnostics Dashboard</h2>
-      <p class="dashboard-intro">Monitor console errors and network connections in real time.</p>
-      <div class="dashboard-grid">
-        <div class="dashboard-panel">
-          <div class="dashboard-panel-header">
-            <h3>Console Logs</h3>
-            <div class="dashboard-controls">
-              <label><input type="checkbox" id="autoScroll" checked /> Auto-scroll</label>
-              <button id="clearLogs" class="btn btn-small btn-secondary">Clear</button>
-            </div>
-          </div>
-          <ul id="dashboardLogs" class="log-list"></ul>
-        </div>
-        <div class="dashboard-panel">
-          <h3>Network Activity</h3>
-          <ul id="fetchLogs" class="tree-list"></ul>
-        </div>
-      </div>
-    </div>
-  </section>
   <section id="contact" class="contact">
     <div class="container">
       <h2 class="section-title">Get In Touch</h2>

--- a/main.css
+++ b/main.css
@@ -899,6 +899,14 @@ body.dark-mode .demo-card {
   align-items: center;
 }
 
+.log-filter {
+  padding: 0.25rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-color);
+ }
+
 .btn-small {
   padding: 0.25rem 0.75rem;
   font-size: 0.875rem;

--- a/main.js
+++ b/main.js
@@ -4,12 +4,10 @@ import { NotificationSystem, initNotificationToggle } from './notifications.js';
 import { setupSecurityDemo, securityFeatures } from './security-demo.js';
 import { validateForm } from './utils.js';
 import { initHeroAnimations } from './hero-animations.js';
-import { initDashboard } from './dashboard.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
   initTheme();
   const navMenu = initNavigation();
-  initDashboard();
   await initHeroAnimations();
 
   const counters = document.querySelectorAll('.stat-number');


### PR DESCRIPTION
## Summary
- remove inline dashboard section and link to new dashboard page
- add log filtering UI to the standalone dashboard
- implement filter logic in dashboard.js
- style new log filter dropdown
- cleanup main.js dashboard initialization

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6852b94067dc832b8ae4390d99165e8f