### PR TITLE
Improve dashboard UI and interactions

### DIFF
--- a/dashboard-page.js
+++ b/dashboard-page.js
@@ -29,13 +29,21 @@ document.addEventListener('DOMContentLoaded', () => {
     errorsEl: document.getElementById('errorsCount'),
     warningsEl: document.getElementById('warningsCount'),
     requestsEl: document.getElementById('requestsCount'),
+    successesEl: document.getElementById('successCount'),
+    failuresEl: document.getElementById('failuresCount'),
   };
 
   initDashboard({
+    searchInputEl: '#logSearch',
+    panelToggleSel: '.panel-toggle',
+    pauseBtnEl: '#pauseLogs',
+    exportBtnEl: '#exportLogs',
     onStats({ errors, warnings, requests, successes, failures }) {
       if (stats.errorsEl) stats.errorsEl.textContent = errors;
       if (stats.warningsEl) stats.warningsEl.textContent = warnings;
       if (stats.requestsEl) stats.requestsEl.textContent = requests;
+      if (stats.successesEl) stats.successesEl.textContent = successes;
+      if (stats.failuresEl) stats.failuresEl.textContent = failures;
       if (chart) {
         chart.data.datasets[0].data = [successes, failures];
         chart.update();

--- a/dashboard.html
+++ b/dashboard.html
@@ -47,19 +47,21 @@
     </div>
   </nav>
 
-  <section class="dashboard-page">
+  <section class="dashboard dashboard-page">
     <div class="container">
       <h1 class="section-title">Diagnostics Dashboard</h1>
       <div class="dashboard-stats">
         <div class="stat"><span id="errorsCount">0</span><small>Errors</small></div>
         <div class="stat"><span id="warningsCount">0</span><small>Warnings</small></div>
         <div class="stat"><span id="requestsCount">0</span><small>Requests</small></div>
+        <div class="stat"><span id="successCount">0</span><small>Successes</small></div>
+        <div class="stat"><span id="failuresCount">0</span><small>Failures</small></div>
       </div>
       <div class="chart-container">
         <canvas id="networkChart" width="400" height="200"></canvas>
       </div>
       <div class="dashboard-grid">
-        <div class="dashboard-panel">
+        <div class="dashboard-panel" id="logsPanel">
           <div class="dashboard-panel-header">
             <h3>Console Logs</h3>
             <div class="dashboard-controls">
@@ -70,13 +72,22 @@
                 <option value="warning">Warnings</option>
                 <option value="info">Info</option>
               </select>
+              <input type="text" id="logSearch" class="log-search" placeholder="Search logs" />
+              <button id="pauseLogs" class="btn btn-small">Pause</button>
+              <button id="exportLogs" class="btn btn-small btn-secondary">Export</button>
               <button id="clearLogs" class="btn btn-small btn-secondary">Clear</button>
+              <button class="panel-toggle btn btn-small" aria-label="Collapse panel">Collapse</button>
             </div>
           </div>
           <ul id="dashboardLogs" class="log-list"></ul>
         </div>
-        <div class="dashboard-panel">
-          <h3>Network Activity</h3>
+        <div class="dashboard-panel" id="networkPanel">
+          <div class="dashboard-panel-header">
+            <h3>Network Activity</h3>
+            <div class="dashboard-controls">
+              <button class="panel-toggle btn btn-small" aria-label="Collapse panel">Collapse</button>
+            </div>
+          </div>
           <ul id="fetchLogs" class="tree-list"></ul>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,6 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&amp;display=swap">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link rel="stylesheet" href="main.css">
-  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAQAAAC1+jfqAAAAI0lEQVR42mNkYGD4z8DAwMDAgAn8j8DAYTAIMwgwGhAIAAOWcBShK5T2wAAAAASUVORK5CYII=" />
   <script type="importmap">
     {
       "imports": {

--- a/main.css
+++ b/main.css
@@ -865,7 +865,8 @@ body.dark-mode .demo-card {
 }
 
 /* Dashboard Section */
-.dashboard {
+.dashboard,
+.dashboard-page {
   padding: 5rem 0;
   background: var(--bg-color);
 }
@@ -897,6 +898,27 @@ body.dark-mode .demo-card {
   display: flex;
   gap: 0.5rem;
   align-items: center;
+}
+
+.log-search {
+  padding: 0.25rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-color);
+}
+
+.panel-toggle {
+  cursor: pointer;
+}
+
+.dashboard-panel.collapsed {
+  max-height: 2.5rem;
+  overflow: hidden;
+}
+
+.dashboard-panel.collapsed > :not(.dashboard-panel-header) {
+  display: none;
 }
 
 .log-filter {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -893,7 +893,8 @@ body.dark-mode .demo-card {
 }
 
 /* Dashboard Section */
-.dashboard {
+.dashboard,
+.dashboard-page {
   padding: 5rem 0;
   background: var(--bg-color);
 }
@@ -925,6 +926,27 @@ body.dark-mode .demo-card {
   display: flex;
   gap: 0.5rem;
   align-items: center;
+}
+
+.log-search {
+  padding: 0.25rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-color);
+}
+
+.panel-toggle {
+  cursor: pointer;
+}
+
+.dashboard-panel.collapsed {
+  max-height: 2.5rem;
+  overflow: hidden;
+}
+
+.dashboard-panel.collapsed > :not(.dashboard-panel-header) {
+  display: none;
 }
 
 .btn-small {


### PR DESCRIPTION
## Summary
- drop favicon references and delete unused file
- add collapsible log panels and search box for logs
- track network success/failure statistics
- enhance dashboard styles with collapse state support
- update dashboard initialization to wire new controls and stats

## Testing
- `npm install`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6852baa10eec832b9d4641ae0fa9bdda