### PR TITLE
Handle global errors in dashboard

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -153,6 +153,22 @@ export function initDashboard(options = {}) {
     origLog.apply(console, args);
   };
 
+  window.addEventListener('error', (e) => {
+    if (!recording) return;
+    const msg = e.message || (e.error && e.error.message) || 'Unknown error';
+    appendLog('error', msg);
+    errors += 1;
+    report();
+  });
+
+  window.addEventListener('unhandledrejection', (e) => {
+    if (!recording) return;
+    const reason = e.reason && e.reason.message ? e.reason.message : e.reason;
+    appendLog('error', reason || 'Unhandled rejection');
+    errors += 1;
+    report();
+  });
+
   const origFetch = window.fetch;
   window.fetch = async (...args) => {
     const url = args[0];

--- a/tests/dashboard.test.js
+++ b/tests/dashboard.test.js
@@ -29,4 +29,28 @@ describe('initDashboard', () => {
     const log = document.querySelector('.log-error');
     expect(log).not.toBeNull();
   });
+
+  test('captures window errors and rejections', () => {
+    document.body.innerHTML = `
+      <ul id="dashboardLogs" class="log-list"></ul>
+      <ul id="fetchLogs" class="tree-list"></ul>
+    `;
+    let stats = null;
+    initDashboard({ onStats: (s) => (stats = s) });
+
+    window.dispatchEvent(new ErrorEvent('error', { message: 'kaboom' }));
+    let logItems = document.querySelectorAll('.log-error');
+    expect(logItems.length).toBe(1);
+    expect(logItems[0].textContent).toMatch('kaboom');
+    expect(stats.errors).toBe(1);
+
+    const rej = new Event('unhandledrejection');
+    rej.reason = new Error('oops');
+    window.dispatchEvent(rej);
+
+    logItems = document.querySelectorAll('.log-error');
+    expect(logItems.length).toBe(2);
+    expect(logItems[1].textContent).toMatch('oops');
+    expect(stats.errors).toBe(2);
+  });
 });


### PR DESCRIPTION
## Summary
- log window `error` events and unhandled promise rejections
- test capturing of window errors and rejections

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6852c0cf1c18832b843793addb340d7d