### PR TITLE
Log resource load errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,19 @@ npm run dev
 - `security-demo.js` – dynamic demo section with cryptography utilities
 - `tests/` – Jest unit tests for utilities and security features
 
+## Diagnostics dashboard
+
+The optional `dashboard.html` page visualizes logs captured by
+`error-capture.js`. Console errors, warnings and fetch requests are stored in
+`localStorage` under the `sgLogs` key. Resource loading issues such as failed
+images or scripts are also tracked by listening for window `'error'` events in
+the capturing phase. When a resource fails to load a log entry is created with a
+message like:
+
+```
+Resource failed to load: <URL>
+```
+
+Opening the dashboard page will display these entries alongside other logs.
+
 

--- a/error-capture.js
+++ b/error-capture.js
@@ -54,10 +54,19 @@ console.log = (...args) => {
   origLog.apply(console, args);
 };
 
-window.addEventListener('error', (e) => {
-  const msg = e.message || (e.error && e.error.message) || 'Unknown error';
-  pushLog({ type: 'error', message: msg });
-});
+window.addEventListener(
+  'error',
+  (e) => {
+    if (e.target && (e.target.src || e.target.href)) {
+      const url = e.target.src || e.target.href;
+      pushLog({ type: 'error', message: `Resource failed to load: ${url}` });
+      return;
+    }
+    const msg = e.message || (e.error && e.error.message) || 'Unknown error';
+    pushLog({ type: 'error', message: msg });
+  },
+  true,
+);
 
 window.addEventListener('unhandledrejection', (e) => {
   const reason = e.reason && e.reason.message ? e.reason.message : e.reason;


### PR DESCRIPTION
## Summary
- capture resource errors with a capturing `error` listener
- store resource error entries alongside other logs
- document the new behaviour and dashboard in `README`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6852c2c1f8c4832ba8a7b74a8a75de51