### PR TITLE
Improve dashboard UI and navigation

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -80,6 +80,10 @@
               <button class="panel-toggle btn btn-small" aria-label="Collapse panel">Collapse</button>
             </div>
           </div>
+          <div id="logsEmpty" class="empty-state">
+            <i class="fas fa-clipboard-list"></i>
+            <p>No logs captured</p>
+          </div>
           <ul id="dashboardLogs" class="log-list"></ul>
         </div>
         <div class="dashboard-panel" id="networkPanel">
@@ -88,6 +92,10 @@
             <div class="dashboard-controls">
               <button class="panel-toggle btn btn-small" aria-label="Collapse panel">Collapse</button>
             </div>
+          </div>
+          <div id="fetchEmpty" class="empty-state">
+            <i class="fas fa-network-wired"></i>
+            <p>No network requests</p>
           </div>
           <ul id="fetchLogs" class="tree-list"></ul>
         </div>

--- a/dashboard/core.js
+++ b/dashboard/core.js
@@ -1,6 +1,8 @@
 export function initDashboard(options = {}) {
   const logList = document.getElementById('dashboardLogs');
   const fetchTree = document.getElementById('fetchLogs');
+  const logsEmpty = document.getElementById('logsEmpty');
+  const fetchEmpty = document.getElementById('fetchEmpty');
   if (!logList || !fetchTree) return;
 
   let errors = 0;
@@ -17,6 +19,13 @@ export function initDashboard(options = {}) {
   const filterSelect = document.querySelector(options.filterSelectEl || '#logFilter');
   const searchInput = document.querySelector(options.searchInputEl || '#logSearch');
   const panelToggles = document.querySelectorAll(options.panelToggleSel || '.panel-toggle');
+
+  const updateEmptyStates = () => {
+    if (logsEmpty) logsEmpty.style.display = logList.children.length ? 'none' : 'block';
+    if (fetchEmpty) fetchEmpty.style.display = fetchTree.children.length ? 'none' : 'block';
+  };
+
+  updateEmptyStates();
 
   let logFilter = filterSelect ? filterSelect.value : 'all';
 
@@ -64,7 +73,7 @@ export function initDashboard(options = {}) {
     const panel = btn.closest('.dashboard-panel');
     if (!panel) return;
     const id = panel.id;
-    if (id && localStorage.getItem(`panel-${id}`) === 'collapsed') {
+    if (id && sessionStorage.getItem(`panel-${id}`) === 'collapsed') {
       panel.classList.add('collapsed');
       btn.textContent = 'Expand';
     }
@@ -72,7 +81,7 @@ export function initDashboard(options = {}) {
       const collapsed = panel.classList.toggle('collapsed');
       btn.textContent = collapsed ? 'Expand' : 'Collapse';
       if (id) {
-        localStorage.setItem(`panel-${id}`, collapsed ? 'collapsed' : 'open');
+        sessionStorage.setItem(`panel-${id}`, collapsed ? 'collapsed' : 'open');
       }
     });
   });
@@ -107,6 +116,7 @@ export function initDashboard(options = {}) {
       fetchHistory.length = 0;
       localStorage.removeItem('sgLogs');
       report();
+      updateEmptyStates();
     });
   }
 
@@ -121,6 +131,7 @@ export function initDashboard(options = {}) {
     logList.appendChild(li);
     logHistory.push({ type, message, timestamp });
     updateVisibility();
+    updateEmptyStates();
     if (autoScroll) {
       logList.scrollTop = logList.scrollHeight;
     }
@@ -152,6 +163,7 @@ export function initDashboard(options = {}) {
       failures += 1;
     }
     fetchHistory.push(entry);
+    updateEmptyStates();
   };
 
   const stored = (() => {
@@ -175,6 +187,7 @@ export function initDashboard(options = {}) {
     ['success', 'failure'].forEach((t) => {
       (stored.fetches[t] || []).forEach((f) => addFetchEntry(f));
     });
+    updateEmptyStates();
   }
   if (stored) {
     report();

--- a/main.css
+++ b/main.css
@@ -71,6 +71,10 @@ body {
   overflow: hidden;
 }
 
+section {
+  scroll-margin-top: 90px;
+}
+
 /* Navigation */
 .navbar {
   position: fixed;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -21,6 +21,10 @@ body {
   overflow: hidden;
 }
 
+section {
+  scroll-margin-top: 90px;
+}
+
 /* Navigation */
 .navbar {
   position: fixed;

--- a/theme.js
+++ b/theme.js
@@ -41,28 +41,45 @@ export function initNavigation() {
   const navToggle = document.querySelector('.nav-toggle');
   const navMenu = document.querySelector('.nav-menu');
   if (!navToggle || !navMenu) return navMenu;
+  const spans = navToggle.querySelectorAll('span');
+
+  const closeMenu = () => {
+    navMenu.classList.remove('active');
+    spans[0].style.transform = '';
+    spans[1].style.opacity = '1';
+    spans[2].style.transform = '';
+    sessionStorage.removeItem('nav-state');
+  };
+
+  const openMenu = () => {
+    navMenu.classList.add('active');
+    spans[0].style.transform = 'rotate(-45deg) translate(-5px, 6px)';
+    spans[1].style.opacity = '0';
+    spans[2].style.transform = 'rotate(45deg) translate(-5px, -6px)';
+    sessionStorage.setItem('nav-state', 'open');
+  };
 
   navToggle.addEventListener('click', () => {
-    navMenu.classList.toggle('active');
-    const spans = navToggle.querySelectorAll('span');
-    spans[0].style.transform = navMenu.classList.contains('active')
-      ? 'rotate(-45deg) translate(-5px, 6px)'
-      : '';
-    spans[1].style.opacity = navMenu.classList.contains('active') ? '0' : '1';
-    spans[2].style.transform = navMenu.classList.contains('active')
-      ? 'rotate(45deg) translate(-5px, -6px)'
-      : '';
+    if (navMenu.classList.contains('active')) {
+      closeMenu();
+    } else {
+      openMenu();
+    }
   });
 
   document.querySelectorAll('.nav-menu a').forEach((link) => {
-    link.addEventListener('click', () => {
-      navMenu.classList.remove('active');
-      const spans = navToggle.querySelectorAll('span');
-      spans[0].style.transform = '';
-      spans[1].style.opacity = '1';
-      spans[2].style.transform = '';
-    });
+    link.addEventListener('click', closeMenu);
   });
+
+  window.addEventListener('resize', () => {
+    if (window.innerWidth > 768 && navMenu.classList.contains('active')) {
+      closeMenu();
+    }
+  });
+
+  if (sessionStorage.getItem('nav-state') === 'open') {
+    openMenu();
+  }
 
   return navMenu;
 }


### PR DESCRIPTION
## Summary
- refine nav menu interaction and restore state only per session
- prevent anchor links from hiding under the nav bar
- show empty states in the dashboard panels
- store collapsed panel state for current session only

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6852cda2beb4832baa639e66b92a9acb