### PR TITLE
Fix dashboard nav ordering

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -18,13 +18,6 @@
   </script>
 </head>
 <body>
-  <button class="theme-toggle" aria-label="Toggle theme">
-    <i class="fas fa-moon"></i>
-  </button>
-  <button class="notification-toggle" aria-label="Toggle notifications" aria-pressed="true">
-    <i class="fas fa-bell"></i>
-  </button>
-
   <nav class="navbar">
     <div class="nav-container">
       <div class="logo">
@@ -48,9 +41,20 @@
     </div>
   </nav>
 
-  <section class="dashboard dashboard-page">
+  <header class="dashboard-header">
+    <button class="theme-toggle" aria-label="Toggle theme">
+      <i class="fas fa-moon"></i>
+    </button>
+    <button class="notification-toggle" aria-label="Toggle notifications" aria-pressed="true">
+      <i class="fas fa-bell"></i>
+    </button>
     <div class="container">
       <h1 class="section-title">Diagnostics Dashboard</h1>
+    </div>
+  </header>
+
+  <section class="dashboard dashboard-page">
+    <div class="container">
       <div class="dashboard-stats">
         <div class="stat"><span id="errorsCount">0</span><small>Errors</small></div>
         <div class="stat"><span id="warningsCount">0</span><small>Warnings</small></div>

--- a/dashboard/dashboard.css
+++ b/dashboard/dashboard.css
@@ -73,6 +73,12 @@ body {
   overflow: hidden;
 }
 
+.dashboard-header {
+  margin-top: 80px;
+  text-align: center;
+  padding: 1rem 0;
+}
+
 .dashboard::before {
   content: "";
   position: absolute;

--- a/src/styles/dashboard.scss
+++ b/src/styles/dashboard.scss
@@ -23,6 +23,13 @@ body {
   overflow: hidden;
 }
 
+/* Offset the fixed navbar */
+.dashboard-header {
+  margin-top: 80px;
+  text-align: center;
+  padding: 1rem 0;
+}
+
 .dashboard::before {
   content: '';
   position: absolute;


### PR DESCRIPTION
## Summary
- reorder dashboard elements so navbar renders before the header
- add dashboard header with theme & notification toggles
- offset content for fixed navbar

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6852ee21572c832b800ede1950deb647