### PR TITLE
Sanitize dashboard log rendering

### DIFF
--- a/dashboard/core.js
+++ b/dashboard/core.js
@@ -155,7 +155,12 @@ export function initDashboard(options = {}) {
     li.className = `log-${type}`;
     li.dataset.type = type;
     const timestamp = new Date().toLocaleTimeString();
-    li.innerHTML = `<span class="log-timestamp">${timestamp}</span> ${message}`;
+    const ts = document.createElement('span');
+    ts.className = 'log-timestamp';
+    ts.textContent = timestamp;
+    li.appendChild(ts);
+    li.appendChild(document.createTextNode(' '));
+    li.appendChild(document.createTextNode(message));
     li.style.display = 'none';
     logList.appendChild(li);
     logHistory.push({ type, message, timestamp });
@@ -168,7 +173,10 @@ export function initDashboard(options = {}) {
 
   const addFetchEntry = (entry) => {
     const node = document.createElement('li');
-    node.innerHTML = `<span class="fetch-url">${entry.url}</span>`;
+    const urlSpan = document.createElement('span');
+    urlSpan.className = 'fetch-url';
+    urlSpan.textContent = entry.url;
+    node.appendChild(urlSpan);
     const children = document.createElement('ul');
     node.appendChild(children);
     fetchTree.appendChild(node);

--- a/tests/dashboard.test.js
+++ b/tests/dashboard.test.js
@@ -70,4 +70,19 @@ describe('initDashboard', () => {
     expect(item).not.toBeNull();
     expect(item.textContent).toMatch('persisted message');
   });
+
+  test('sanitizes log entries containing HTML', async () => {
+    document.body.innerHTML = `
+      <ul id="dashboardLogs" class="log-list"></ul>
+      <ul id="fetchLogs" class="tree-list"></ul>
+    `;
+    localStorage.clear();
+    const { initDashboard } = await import('../dashboard/core.js');
+    initDashboard();
+    console.log('<img src=x onerror="window.hacked=true">');
+    const item = document.querySelector('.log-info');
+    expect(item).not.toBeNull();
+    expect(item.textContent).toMatch('<img src=x onerror="window.hacked=true">');
+    expect(document.querySelector('img')).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- sanitize log entries by inserting them as text nodes
- safely insert fetch URLs
- test HTML log sanitization

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6852fc16727c832b99f87d6ad645461b