### PR TITLE
Harden CSP policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ up startup and ensure the necessary modules are available when the page loads.
 
 This starts a local web server and automatically opens the site in your browser. Using a server avoids CORS restrictions that occur when opening `index.html` directly from the file system. Running `npm install` ensures the required modules are available when the page loads.
 
+The development server also sends a strict Content Security Policy and
+`Strict-Transport-Security` header. Inline scripts and styles are blocked, so
+all code is loaded from external files. This mirrors a hardened production setup
+and helps catch policy violations during development.
+
 Alternatively you can use the development server provided by Vite (requires Node.js and dependencies):
 
 ```bash

--- a/dashboard.html
+++ b/dashboard.html
@@ -9,13 +9,7 @@
   <link rel="stylesheet" href="main.css">
   <link rel="stylesheet" href="dashboard/dashboard.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-9nhczxUqK87bcKHh20fSQcTGD4qq5GhayNYSYWqwBkINBhOfQLg/P5HG5lF1urn4" crossorigin="anonymous" defer></script>
-  <script type="importmap">
-    {
-      "imports": {
-        "animejs": "./node_modules/animejs/lib/anime.esm.js"
-      }
-    }
-  </script>
+  <script type="importmap" src="importmap.json"></script>
 </head>
 <body>
   <nav class="navbar">

--- a/importmap.json
+++ b/importmap.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "animejs": "./node_modules/animejs/lib/anime.esm.js"
+  }
+}

--- a/index.html
+++ b/index.html
@@ -7,13 +7,7 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&amp;display=swap" integrity="sha384-5iLhiAMnxM+tvsp4jKxMYmpKxvZL42MW4uVufHht0BVlXYOb0CXts5eEkK9wJ+nI" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0" crossorigin="anonymous">
   <link rel="stylesheet" href="main.css">
-  <script type="importmap">
-    {
-      "imports": {
-        "animejs": "./node_modules/animejs/lib/anime.esm.js"
-      }
-    }
-  </script>
+  <script type="importmap" src="importmap.json"></script>
 </head>
 <body class="no-scroll">
   <div id="preloader">
@@ -244,11 +238,6 @@
     </div>
   </div>
 
-  <script>
-    if (location.protocol === 'file:') {
-      document.body.innerHTML = '<p style="padding:2rem;font-size:1.2rem">Please run this site via a local server (e.g., <code>python security.py</code>) to avoid CORS issues.</p>';
-    }
-  </script>
   <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -6,6 +6,13 @@ import { setupSecurityDemo, securityFeatures } from './security-demo.js';
 import { validateForm, getCSRFToken, validateCSRFToken } from './utils.js';
 import { initHeroAnimations } from './hero-animations.js';
 
+if (window.location.protocol === 'file:') {
+  document.addEventListener('DOMContentLoaded', () => {
+    document.body.innerHTML =
+      '<p style="padding:2rem;font-size:1.2rem">Please run this site via a local server (e.g., <code>python security.py</code>) to avoid CORS issues.</p>';
+  });
+}
+
 document.addEventListener('DOMContentLoaded', async () => {
   initTheme();
   const navMenu = initNavigation();

--- a/security.py
+++ b/security.py
@@ -34,7 +34,7 @@ class SecureHandler(SimpleHTTPRequestHandler):
     def end_headers(self) -> None:  # type: ignore[override]
         self.send_header(
             "Content-Security-Policy",
-            "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'"
+            "default-src 'self'; script-src 'self'; style-src 'self'"
         )
         self.send_header("X-Content-Type-Options", "nosniff")
         self.send_header("Referrer-Policy", "no-referrer")


### PR DESCRIPTION
## Summary
- tighten up the dev server CSP
- move importmap JSON to an external file and drop inline script
- shift protocol warning logic into `main.js`
- mention strict CSP and HSTS in the README

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6852fdc3ab40832b8ce178621aecb35f