### PR TITLE
Add npm audit workflow

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,17 @@
+name: Security Audit
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  npm-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm audit --production --audit-level=high

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ npm run dev
 
 - `npm test` – run the Jest unit tests
 - `npm run lint` – run ESLint and Stylelint
+- `npm run audit` – check dependencies for vulnerabilities (fails on high severity)
 
 ## Project structure
 
@@ -83,4 +84,9 @@ other parts of the app to stream logs in real-time. The page provides global
 controls to collapse or expand all panels and uses `localStorage` to persist
 panel state and captured logs between visits.
 
+
+
+## Security auditing
+
+A GitHub Actions workflow automatically runs `npm audit` on every push and pull request. The build fails if any high-severity vulnerabilities are found. You can run the same check locally with `npm run audit`.
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "npm run lint:js && npm run lint:css",
     "lint:js": "eslint --no-error-on-unmatched-pattern *.js src/**/*.js tests/**/*.js",
     "lint:css": "stylelint nonexistent.css --allow-empty-input",
+    "audit": "npm audit --production --audit-level=high",
     "dev": "vite",
     "build": "vite build",
     "serve": "vite preview"


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that runs `npm audit` on pushes and PRs
- add `npm run audit` script to package.json
- document audit workflow in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853039e0838832b86c65098c212910e