### PR TITLE
Fix auto-merge workflow token

### DIFF
--- a/.github/workflows/Auto-merge.yml
+++ b/.github/workflows/Auto-merge.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Merge PR if possible
         uses: actions/github-script@v7
         with:
-          github-token: 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
+          github-token: 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
           script: |
             const { owner, repo } = context.repo
             let   pr              // <-- will be updated while polling


### PR DESCRIPTION
## Summary
- use the provided PAT for the auto-merge workflow

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685301a80cf0832ba962e9e903423324