### PR TITLE
Add hash verification for hero animations CDN

### DIFF
--- a/hero-animations.js
+++ b/hero-animations.js
@@ -2,6 +2,12 @@
 // when served by a simple HTTP server without a bundler.
 let animeModule;
 
+const CDN_URL =
+  'https://cdn.jsdelivr.net/npm/animejs@4.0.2/lib/anime.esm.min.js';
+// sha256 hash of the file at CDN_URL (hex encoded)
+const EXPECTED_CDN_HASH =
+  'e8eb5b27f49049d82da9cebd01d3809ea5141f6d524f2960824345e0ca45f237';
+
 async function loadAnime() {
   try {
     const res = await fetch('./node_modules/animejs/lib/anime.esm.js', { method: 'HEAD' });
@@ -13,7 +19,24 @@ async function loadAnime() {
   } catch (err) {
     console.warn('Local Anime.js not found, loading from CDN...', err);
     try {
-      animeModule = await import('https://cdn.jsdelivr.net/npm/animejs@4.0.2/lib/anime.esm.min.js');
+      const res = await fetch(CDN_URL);
+      const text = await res.text();
+      const encoder = new TextEncoder();
+      const data = encoder.encode(text);
+      const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+      const hashArray = Array.from(new Uint8Array(hashBuffer));
+      const hashHex = hashArray
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('');
+      if (hashHex !== EXPECTED_CDN_HASH) {
+        console.warn('Anime.js CDN hash mismatch. Animations disabled.');
+        animeModule = null;
+        return;
+      }
+      const blob = new Blob([text], { type: 'application/javascript' });
+      const blobURL = URL.createObjectURL(blob);
+      animeModule = await import(blobURL);
+      URL.revokeObjectURL(blobURL);
     } catch (cdnErr) {
       console.error('Failed to load Anime.js from CDN', cdnErr);
       animeModule = null;


### PR DESCRIPTION
## Summary
- verify Anime.js CDN download with a SHA-256 hash before evaluating

## Testing
- `npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68531018f014832ba01112ce2a2a8b75