### PR TITLE
Update CSP and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ The example above permits ten requests from the same IP within a two second
 window before subsequent requests are rejected. The `Retry-After` header of the
 response indicates how long clients should wait before retrying.
 
+The default Content Security Policy now includes `img-src 'self' data:` so that
+local images and data URIs load without triggering browser CSP errors.
+
 Alternatively you can use the development server provided by Vite (requires Node.js and dependencies):
 
 ```bash

--- a/security.py
+++ b/security.py
@@ -90,7 +90,7 @@ class SecureHandler(SimpleHTTPRequestHandler):
     # ``{nonce}`` placeholder to automatically inject a per-request nonce.
     csp_template = os.environ.get(
         "CONTENT_SECURITY_POLICY",
-        "default-src 'self'; script-src 'self' {nonce}; style-src 'self'",
+        "default-src 'self'; img-src 'self' data:; script-src 'self' {nonce}; style-src 'self'",
     )
 
     def end_headers(self) -> None:  # type: ignore[override]


### PR DESCRIPTION
## Summary
- allow data URI images in the default Content Security Policy
- document the updated policy in the rate limiting section

## Testing
- `npm test`
- manual start of `python3 security.py` and `curl -I http://localhost:8003/`

------
https://chatgpt.com/codex/tasks/task_e_685320d951dc832b9fbedc19840545ea