### PR TITLE
Update rate limit defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ and helps catch policy violations during development.
 address. When a client exceeds the allowed number of requests within the
 configured time window, the server responds with **HTTP 429 Too Many Requests**.
 
-The defaults allow **5** requests every **1** second. You can adjust these
+The defaults allow **20** requests every **1** second. You can adjust these
 limits by setting the environment variables `MAX_REQUESTS` and `RATE_WINDOW`:
 
 ```bash

--- a/security.py
+++ b/security.py
@@ -82,7 +82,7 @@ class SecureHandler(SimpleHTTPRequestHandler):
     """HTTP handler that injects security headers for every response."""
 
     rate_limiter = RateLimiter(
-        int(os.environ.get("MAX_REQUESTS", "5")),
+        int(os.environ.get("MAX_REQUESTS", "20")),
         int(os.environ.get("RATE_WINDOW", "1")),
     )
 
@@ -306,7 +306,7 @@ def _find_free_port(start: int = 8000) -> int:
 def main() -> None:
     _ensure_node_deps()
     compile_scss()
-    limit = int(os.environ.get("MAX_REQUESTS", "5"))
+    limit = int(os.environ.get("MAX_REQUESTS", "20"))
     window = int(os.environ.get("RATE_WINDOW", "1"))
     SecureHandler.rate_limiter = RateLimiter(limit, window)
     port = int(os.environ.get("PORT", _find_free_port()))


### PR DESCRIPTION
## Summary
- bump rate limit default to 20 requests
- document new rate limit defaults

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853224b3b1c832b8d8436e9bbaef7ae