### PR TITLE
Add font checks for security server

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm install -g sass
 ```
 
 ```bash
-npm install   # install dependencies such as Anime.js
+npm install   # install dependencies such as Anime.js, fonts and icons
 python security.py
 ```
 
@@ -33,6 +33,7 @@ Run `npm install` before any `npm test` or `python security.py` command to
 ensure all dependencies are available.
 
 If dependencies are missing, scripts like the hero animations may fail to load
+or styles may not find the Poppins font and Font Awesome icons
 (resulting in 404 errors for files under `node_modules`). The `security.py`
 server automatically attempts to run `npm install` when these packages are not
 found. Running `npm install` manually beforehand is still recommended to speed

--- a/security.py
+++ b/security.py
@@ -184,15 +184,31 @@ class SecureHandler(SimpleHTTPRequestHandler):
 
 
 def _ensure_node_deps() -> None:
-    """Install Node dependencies if ``animejs`` is missing."""
+    """Install Node dependencies if required assets are missing."""
     anime_path = ROOT_DIR / "node_modules" / "animejs" / "lib" / "anime.esm.js"
-    if anime_path.exists():
+    poppins_path = (
+        ROOT_DIR
+        / "node_modules"
+        / "@fontsource"
+        / "poppins"
+        / "index.css"
+    )
+    fa_path = (
+        ROOT_DIR
+        / "node_modules"
+        / "@fortawesome"
+        / "fontawesome-free"
+        / "css"
+        / "all.min.css"
+    )
+
+    if anime_path.exists() and poppins_path.exists() and fa_path.exists():
         return
 
     npm_cmd = shutil.which("npm") or shutil.which("npm.cmd")
     if not npm_cmd:
         print(
-            "Anime.js dependency missing and npm not found. "
+            "Required Node dependencies missing and npm not found. "
             "Install Node.js and run 'npm install' manually."
         )
         return


### PR DESCRIPTION
## Summary
- install node deps when font files are missing
- clarify that `npm install` also installs fonts and icons

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68532608c9fc832b806846572b3134f2