### PR TITLE
Use local Chart.js bundle

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -6,7 +6,7 @@
   <title>SecureGuard Dashboard</title>
   <link rel="stylesheet" href="main.css">
   <link rel="stylesheet" href="dashboard/dashboard.css">
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-9nhczxUqK87bcKHh20fSQcTGD4qq5GhayNYSYWqwBkINBhOfQLg/P5HG5lF1urn4" crossorigin="anonymous" defer></script>
+  <script src="node_modules/chart.js/dist/chart.umd.js" defer></script>
   <script type="importmap" src="importmap.json"></script>
 </head>
 <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@fontsource/poppins": "^5.0.0",
         "@fortawesome/fontawesome-free": "^6.5.2",
         "animejs": "^4.0.2",
+        "chart.js": "^4.4.1",
         "dompurify": "^3.2.6"
       },
       "devDependencies": {
@@ -2118,6 +2119,12 @@
         "buffer": "^6.0.3"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.11.tgz",
@@ -3945,6 +3952,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chokidar": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "animejs": "^4.0.2",
     "dompurify": "^3.2.6",
     "@fontsource/poppins": "^5.0.0",
-    "@fortawesome/fontawesome-free": "^6.5.2"
+    "@fortawesome/fontawesome-free": "^6.5.2",
+    "chart.js": "^4.4.1"
   }
 }


### PR DESCRIPTION
## Summary
- add Chart.js to dependencies
- swap dashboard Chart.js CDN script for local bundle
- keep local Content Security Policy

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685326c62674832ba4255480367610f3