### PR TITLE
Fix DOMPurify import path

### DIFF
--- a/importmap.json
+++ b/importmap.json
@@ -1,6 +1,6 @@
 {
   "imports": {
     "animejs": "./node_modules/animejs/lib/anime.esm.js",
-    "dompurify": "./node_modules/dompurify/dist/purify.es.js"
+    "dompurify": "./node_modules/dompurify/dist/purify.es.mjs"
   }
 }

--- a/security-demo.js
+++ b/security-demo.js
@@ -1,5 +1,7 @@
 import { checkPasswordStrength } from './utils.js';
-import DOMPurify from 'dompurify';
+// Import DOMPurify directly from the local node_modules directory so the module
+// resolution works even when import maps are not supported by the browser.
+import DOMPurify from './node_modules/dompurify/dist/purify.es.mjs';
 
 export const securityFeatures = {
   key: null,


### PR DESCRIPTION
## Summary
- load DOMPurify from local `node_modules` path
- update import map to use the `.mjs` build

## Testing
- `npm test`
- `npm run lint`
- `npm run audit`


------
https://chatgpt.com/codex/tasks/task_e_68532ae4d9d4832bb05e3d56f4213508