### PR TITLE
Update CSP for Unsplash images

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ The example above permits ten requests from the same IP within a two second
 window before subsequent requests are rejected. The `Retry-After` header of the
 response indicates how long clients should wait before retrying.
 
-The default Content Security Policy now includes `img-src 'self' data:` so that
-local images and data URIs load without triggering browser CSP errors.
+The default Content Security Policy now includes `img-src 'self' data: https://images.unsplash.com` so that
+local images, data URIs, and the Unsplash images used in the demo load without triggering browser CSP errors.
 
 Alternatively you can use the development server provided by Vite (requires Node.js and dependencies):
 

--- a/security.py
+++ b/security.py
@@ -90,7 +90,7 @@ class SecureHandler(SimpleHTTPRequestHandler):
     # ``{nonce}`` placeholder to automatically inject a per-request nonce.
     csp_template = os.environ.get(
         "CONTENT_SECURITY_POLICY",
-        "default-src 'self'; img-src 'self' data:; script-src 'self' 'blob:' https://cdn.jsdelivr.net {nonce}; style-src 'self'",
+        "default-src 'self'; img-src 'self' data: https://images.unsplash.com; script-src 'self' 'blob:' https://cdn.jsdelivr.net {nonce}; style-src 'self'",
     )
 
     def end_headers(self) -> None:  # type: ignore[override]


### PR DESCRIPTION
## Summary
- allow Unsplash-hosted images in the default Content Security Policy
- document Unsplash origin in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853e758dc00832b843c8e2d5ef594d9