### PR TITLE
Implement OS color scheme detection

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -3,10 +3,21 @@ export function initTheme() {
   const body = document.body;
   if (!themeToggle) return;
   const icon = themeToggle.querySelector('i');
-  const currentTheme = localStorage.getItem('theme');
-  if (currentTheme === 'dark') {
+  let theme = localStorage.getItem('theme');
+
+  if (!theme) {
+    const prefersDark =
+      window.matchMedia &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches;
+    theme = prefersDark ? 'dark' : 'light';
+  }
+
+  if (theme === 'dark') {
     body.classList.add('dark-mode');
     icon.classList.replace('fa-moon', 'fa-sun');
+  } else {
+    body.classList.remove('dark-mode');
+    icon.classList.replace('fa-sun', 'fa-moon');
   }
 
   themeToggle.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- initialize theme based on browser `prefers-color-scheme`
- clean up theme class when switching back to light mode
- test OS preference detection and theme toggling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854215107cc832b88dc96f5e6631a5f