### PR TITLE
Lazy-load Chart.js in dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ other parts of the app to stream logs in real-time. The page provides global
 controls to collapse or expand all panels and uses `localStorage` to persist
 panel state and captured logs between visits.
 
+Chart.js powering the network activity visualization is loaded on demand when the dashboard initializes, reducing the amount of JavaScript downloaded on first load.
+
 
 
 ## Security auditing

--- a/dashboard.html
+++ b/dashboard.html
@@ -6,7 +6,6 @@
   <title>SecureGuard Dashboard</title>
   <link rel="stylesheet" href="main.css">
   <link rel="stylesheet" href="dashboard/dashboard.css">
-  <script src="node_modules/chart.js/dist/chart.umd.js" defer></script>
   <script type="importmap" src="importmap.json"></script>
 </head>
 <body>

--- a/dashboard/index.js
+++ b/dashboard/index.js
@@ -5,9 +5,10 @@ import { NotificationSystem, initNotificationToggle } from '../notifications.js'
 import { initDashboard } from './core.js';
 import { initScrollOrb } from '../scroll-orb.js';
 
-function setupChart() {
+async function setupChart() {
   const ctx = document.getElementById('networkChart');
-  if (!ctx || !window.Chart) return null;
+  if (!ctx) return null;
+  const { default: Chart } = await import('../node_modules/chart.js/auto');
   return new Chart(ctx, {
     type: 'doughnut',
     data: {
@@ -18,7 +19,7 @@ function setupChart() {
   });
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
   initTheme();
   const navMenu = initNavigation();
   initScrollOrb();
@@ -27,7 +28,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const notifications = new NotificationSystem();
   initNotificationToggle(notifications);
 
-  const chart = setupChart();
+  const chart = await setupChart();
   const stats = {
     errorsEl: document.getElementById('errorsCount'),
     warningsEl: document.getElementById('warningsCount'),


### PR DESCRIPTION
## Summary
- remove Chart.js script tag from dashboard.html
- load Chart.js dynamically inside dashboard/index.js
- document dynamic loading of Chart.js in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854559bd8b8832bbf8d5ac8eeca0205