### PR TITLE
Hide preloader when JavaScript disabled

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -9,6 +9,10 @@
   <script type="importmap" src="importmap.json"></script>
 </head>
 <body>
+  <noscript>
+    <style>#preloader{display:none!important}</style>
+    <div class="no-js-message">This dashboard requires JavaScript to function properly.</div>
+  </noscript>
   <div class="scroll-orb" aria-hidden="true"></div>
   <nav class="navbar">
     <div class="nav-container">

--- a/index.html
+++ b/index.html
@@ -11,6 +11,10 @@
   <div id="preloader">
     <div class="loading-spinner"></div>
   </div>
+  <noscript>
+    <style>#preloader{display:none!important}</style>
+    <div class="no-js-message">This site requires JavaScript to function properly.</div>
+  </noscript>
   <div class="scroll-orb" aria-hidden="true"></div>
   <button class="theme-toggle" aria-label="Toggle theme">
     <i class="fas fa-moon">&#8203;</i>


### PR DESCRIPTION
## Summary
- add `<noscript>` fallback to hide `#preloader` on the main site
- add `<noscript>` fallback to hide `#preloader` on the dashboard

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685457756018832bbf0a1480eb8dafc5