### PR TITLE
Implement scroll orb responsiveness

### DIFF
--- a/scroll-orb.js
+++ b/scroll-orb.js
@@ -1,19 +1,41 @@
 let orb;
+let enabled = true;
+let throttleId = null;
 let ticking = false;
 
 function update() {
+  if (!enabled) {
+    ticking = false;
+    return;
+  }
   const offset = window.scrollY * 0.2;
   orb.style.transform = `translate3d(-50%, calc(-50% + ${offset}px), 0)`;
   ticking = false;
 }
 
-export function initScrollOrb() {
+function checkWidth(threshold) {
+  enabled = window.innerWidth >= threshold;
+  if (!enabled) {
+    orb.style.transform = 'translate3d(-50%, -50%, 0)';
+  } else {
+    update();
+  }
+}
+
+export function initScrollOrb(threshold = 768) {
   orb = document.querySelector('.scroll-orb');
   if (!orb) return;
+  checkWidth(threshold);
+  window.addEventListener('resize', () => checkWidth(threshold));
   window.addEventListener('scroll', () => {
-    if (!ticking) {
-      requestAnimationFrame(update);
-      ticking = true;
-    }
+    if (!enabled) return;
+    if (throttleId) return;
+    throttleId = setTimeout(() => {
+      if (!ticking) {
+        requestAnimationFrame(update);
+        ticking = true;
+      }
+      throttleId = null;
+    }, 20);
   });
 }

--- a/tests/scrollOrb.test.js
+++ b/tests/scrollOrb.test.js
@@ -1,0 +1,17 @@
+import { jest } from '@jest/globals';
+import { initScrollOrb } from '../scroll-orb.js';
+
+describe('initScrollOrb', () => {
+  test('orb does not update when screen width below threshold', () => {
+    document.body.innerHTML = '<div class="scroll-orb"></div>';
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 500 });
+    Object.defineProperty(window, 'scrollY', { writable: true, configurable: true, value: 100 });
+    jest.useFakeTimers();
+    initScrollOrb(768);
+    window.dispatchEvent(new Event('scroll'));
+    jest.runAllTimers();
+    const orb = document.querySelector('.scroll-orb');
+    expect(orb.style.transform).toBe('translate3d(-50%, -50%, 0)');
+    jest.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- disable scroll orb effect when the screen is narrow
- throttle scroll orb updates on scroll
- test that the orb does not animate when disabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854586d1ee0832bb72e88d80fad5ddd