### PR TITLE
Fix CSP header and Chart.js path

### DIFF
--- a/dashboard/index.js
+++ b/dashboard/index.js
@@ -8,7 +8,7 @@ import { initScrollOrb } from '../scroll-orb.js';
 async function setupChart() {
   const ctx = document.getElementById('networkChart');
   if (!ctx) return null;
-  const { default: Chart } = await import('../node_modules/chart.js/auto');
+  const { default: Chart } = await import('../node_modules/chart.js/auto/auto.js');
   return new Chart(ctx, {
     type: 'doughnut',
     data: {

--- a/security.py
+++ b/security.py
@@ -90,7 +90,7 @@ class SecureHandler(SimpleHTTPRequestHandler):
     # ``{nonce}`` placeholder to automatically inject a per-request nonce.
     csp_template = os.environ.get(
         "CONTENT_SECURITY_POLICY",
-        "default-src 'self'; img-src 'self' data: https://images.unsplash.com; script-src 'self' 'blob:' https://cdn.jsdelivr.net {nonce}; style-src 'self'",
+        "default-src 'self'; img-src 'self' data: https://images.unsplash.com; script-src 'self' blob: https://cdn.jsdelivr.net {nonce}; style-src 'self'",
     )
 
     def end_headers(self) -> None:  # type: ignore[override]


### PR DESCRIPTION
## Summary
- allow `blob:` scheme in CSP by removing quotes
- reference Chart.js correctly for dynamic imports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68546a72e2d4832b99ca8ddb8eafee21