### PR TITLE
Fix Chart.js import path

### DIFF
--- a/dashboard/index.js
+++ b/dashboard/index.js
@@ -8,15 +8,20 @@ import { initScrollOrb } from '../scroll-orb.js';
 async function setupChart() {
   const ctx = document.getElementById('networkChart');
   if (!ctx) return null;
-  const { default: Chart } = await import('chart.js/auto');
-  return new Chart(ctx, {
-    type: 'doughnut',
-    data: {
-      labels: ['Success', 'Failed'],
-      datasets: [{ data: [0, 0], backgroundColor: ['#22c55e', '#ef4444'] }],
-    },
-    options: { responsive: true, maintainAspectRatio: false },
-  });
+  try {
+    const { default: Chart } = await import('chart.js/auto');
+    return new Chart(ctx, {
+      type: 'doughnut',
+      data: {
+        labels: ['Success', 'Failed'],
+        datasets: [{ data: [0, 0], backgroundColor: ['#22c55e', '#ef4444'] }],
+      },
+      options: { responsive: true, maintainAspectRatio: false },
+    });
+  } catch (err) {
+    console.error('Failed to load Chart.js', err);
+    return null;
+  }
 }
 
 document.addEventListener('DOMContentLoaded', async () => {

--- a/importmap.json
+++ b/importmap.json
@@ -2,6 +2,6 @@
   "imports": {
     "animejs": "./node_modules/animejs/lib/anime.esm.js",
     "dompurify": "./node_modules/dompurify/dist/purify.es.mjs",
-    "chart.js/auto": "./node_modules/chart.js/auto/auto.js"
+    "chart.js/auto": "https://cdn.jsdelivr.net/npm/chart.js@4.4.1/auto/auto.js"
   }
 }

--- a/tests/chartImportFail.test.js
+++ b/tests/chartImportFail.test.js
@@ -1,0 +1,28 @@
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../search.js', () => ({ initSearch: () => {} }));
+jest.unstable_mockModule('chart.js/auto', () => {
+  throw new Error('missing');
+});
+
+const loadDashboard = () => import('../dashboard/index.js');
+
+test('dashboard handles missing Chart.js gracefully', async () => {
+  document.body.innerHTML = `
+    <canvas id="networkChart"></canvas>
+    <ul id="dashboardLogs"></ul>
+    <ul id="fetchLogs"></ul>
+    <span id="errorsCount"></span>
+    <span id="warningsCount"></span>
+    <span id="requestsCount"></span>
+    <span id="successCount"></span>
+    <span id="failuresCount"></span>
+  `;
+  localStorage.clear();
+  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  await loadDashboard();
+  document.dispatchEvent(new Event('DOMContentLoaded'));
+  await new Promise((r) => setTimeout(r, 0));
+  expect(errorSpy).toHaveBeenCalled();
+  errorSpy.mockRestore();
+});


### PR DESCRIPTION
## Summary
- fix Chart.js import path
- handle missing Chart.js gracefully
- add unit test for Chart.js load failure

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68547527fd24832b87ab72baefbfb6ed