### PR TITLE
Fix Chart.js import handling

### DIFF
--- a/dashboard/index.js
+++ b/dashboard/index.js
@@ -19,8 +19,22 @@ async function setupChart() {
       options: { responsive: true, maintainAspectRatio: false },
     });
   } catch (err) {
-    console.error('Failed to load Chart.js', err);
-    return null;
+    try {
+      const { default: Chart } = await import(
+        'https://cdn.jsdelivr.net/npm/chart.js@4.4.1/auto/auto.js'
+      );
+      return new Chart(ctx, {
+        type: 'doughnut',
+        data: {
+          labels: ['Success', 'Failed'],
+          datasets: [{ data: [0, 0], backgroundColor: ['#22c55e', '#ef4444'] }],
+        },
+        options: { responsive: true, maintainAspectRatio: false },
+      });
+    } catch (err2) {
+      console.error('Failed to load Chart.js', err2);
+      return null;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure dashboard chart falls back to CDN when module resolution fails

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6854782b49a4832b828e5a8baa0b4932