### PR TITLE
Improve Chart.js loading

### DIFF
--- a/importmap.json
+++ b/importmap.json
@@ -2,6 +2,6 @@
   "imports": {
     "animejs": "./node_modules/animejs/lib/anime.esm.js",
     "dompurify": "./node_modules/dompurify/dist/purify.es.mjs",
-    "chart.js/auto": "https://esm.sh/chart.js@4.5.0?bundle"
+    "chart.js/auto": "./node_modules/chart.js/auto/auto.js"
   }
 }


### PR DESCRIPTION
## Summary
- cache Chart.js import to avoid reloading and keep fallback
- load local Chart.js path via import map

## Testing
- `npm test`
- `npm run lint`
- `npm run audit`


------
https://chatgpt.com/codex/tasks/task_e_6854804ef0e8832bb9e21b4c350cb77c