### PR TITLE
Add hero subtitle typing animation

### DIFF
--- a/hero-animations.js
+++ b/hero-animations.js
@@ -2,6 +2,23 @@
 // when served by a simple HTTP server without a bundler.
 let animeModule;
 
+export function typeSubtitle(element, text, interval = 50) {
+  return new Promise((resolve) => {
+    let i = 0;
+    element.textContent = '';
+    element.classList.add('typing');
+    const id = setInterval(() => {
+      element.textContent += text[i];
+      i += 1;
+      if (i >= text.length) {
+        clearInterval(id);
+        element.classList.remove('typing');
+        resolve();
+      }
+    }, interval);
+  });
+}
+
 const CDN_URL =
   'https://cdn.jsdelivr.net/npm/animejs@4.0.2/lib/anime.esm.min.js';
 // sha256 hash of the file at CDN_URL (hex encoded)
@@ -59,6 +76,12 @@ export async function initHeroAnimations() {
 
   const { animate, stagger, timeline } = animeModule;
 
+  const subtitleEl = document.querySelector('.hero-subtitle');
+  const subtitleText = subtitleEl?.textContent || '';
+  if (subtitleEl) {
+    subtitleEl.textContent = '';
+  }
+
   const tl = timeline({ easing: 'easeOutCubic', duration: 700 });
 
   tl.add({
@@ -107,4 +130,9 @@ export async function initHeroAnimations() {
     delay: stagger(200, { start: 1200 }),
     duration: 6000,
   });
+
+  if (subtitleEl) {
+    await tl.finished;
+    await typeSubtitle(subtitleEl, subtitleText, 75);
+  }
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -177,6 +177,16 @@ section {
   color: rgb(255 255 255 / 90%);
   margin-bottom: 2rem;
   animation: fade-in-up 0.8s ease 0.2s both;
+  &.typing::after {
+    content: '';
+    display: inline-block;
+    width: 1px;
+    height: 1em;
+    margin-left: 0.1em;
+    background: currentColor;
+    vertical-align: bottom;
+    animation: blink-cursor 1s steps(2, start) infinite;
+  }
 }
 
 .hero-buttons {
@@ -678,6 +688,16 @@ body.dark-mode .scroll-orb {
 
   50% {
     transform: translateY(-50%) translateX(20px);
+  }
+}
+
+@keyframes blink-cursor {
+  0%, 50% {
+    opacity: 1;
+  }
+
+  50.01%, 100% {
+    opacity: 0;
   }
 }
 

--- a/tests/heroAnimations.test.js
+++ b/tests/heroAnimations.test.js
@@ -1,0 +1,20 @@
+import { jest } from '@jest/globals';
+import { typeSubtitle } from '../hero-animations.js';
+
+describe('typeSubtitle', () => {
+  test('gradually inserts characters', async () => {
+    document.body.innerHTML = '<p class="hero-subtitle"></p>';
+    const el = document.querySelector('.hero-subtitle');
+    jest.useFakeTimers();
+    const promise = typeSubtitle(el, 'Hey', 50);
+    expect(el.textContent).toBe('');
+    jest.advanceTimersByTime(50);
+    expect(el.textContent).toBe('H');
+    jest.advanceTimersByTime(50);
+    expect(el.textContent).toBe('He');
+    jest.advanceTimersByTime(50);
+    expect(el.textContent).toBe('Hey');
+    await promise;
+    jest.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- add `typeSubtitle` helper to animate text typing
- invoke typing after hero timeline completes
- style hero subtitle with blinking cursor
- test typing helper with Jest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685508c71064832ba982302afb8e512d