### PR TITLE
Improve fade-out link transitions

### DIFF
--- a/main.css
+++ b/main.css
@@ -76,6 +76,10 @@ body {
   transition: background 0.3s ease, color 0.3s ease, opacity 0.3s ease;
 }
 
+body.page-exit {
+  opacity: 0;
+}
+
 .scroll-orb {
   position: fixed;
   top: 50%;
@@ -105,8 +109,7 @@ section {
   top: 0;
   width: 100%;
   background: rgba(255, 255, 255, 0.6);
-  -webkit-backdrop-filter: blur(20px);
-          backdrop-filter: blur(20px);
+  backdrop-filter: blur(20px);
   border-bottom: 1px solid rgba(255, 255, 255, 0.4);
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
   z-index: 1000;
@@ -237,6 +240,16 @@ section {
   color: rgba(255, 255, 255, 0.9);
   margin-bottom: 2rem;
   animation: fade-in-up 0.8s ease 0.2s both;
+}
+.hero-subtitle.typing::after {
+  content: "";
+  display: inline-block;
+  width: 1px;
+  height: 1em;
+  margin-left: 0.1em;
+  background: currentColor;
+  vertical-align: bottom;
+  animation: blink-cursor 1s steps(2, start) infinite;
 }
 
 .hero-buttons {
@@ -397,8 +410,7 @@ section {
 
 .feature-card {
   background: rgba(255, 255, 255, 0.7);
-  -webkit-backdrop-filter: blur(10px);
-          backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
   border: 1px solid rgba(255, 255, 255, 0.4);
   padding: 2rem;
   border-radius: 12px;
@@ -492,8 +504,7 @@ section {
   margin-bottom: 3rem;
   padding: 2rem;
   background: rgba(255, 255, 255, 0.7);
-  -webkit-backdrop-filter: blur(10px);
-          backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
   border: 1px solid rgba(255, 255, 255, 0.4);
   border-radius: 12px;
   box-shadow: var(--card-shadow);
@@ -727,6 +738,14 @@ body.dark-mode .scroll-orb {
   }
   50% {
     transform: translateY(-50%) translateX(20px);
+  }
+}
+@keyframes blink-cursor {
+  0%, 50% {
+    opacity: 1;
+  }
+  50.01%, 100% {
+    opacity: 0;
   }
 }
 /* Responsive Design */
@@ -974,8 +993,7 @@ body.dark-mode .demo-card {
   border-radius: 5px;
   font-size: 1rem;
   background: rgba(255, 255, 255, 0.6);
-  -webkit-backdrop-filter: blur(5px);
-          backdrop-filter: blur(5px);
+  backdrop-filter: blur(5px);
   transition: border-color 0.3s ease;
 }
 

--- a/main.js
+++ b/main.js
@@ -8,6 +8,49 @@ import { initHeroAnimations } from './hero-animations.js';
 import { initScrollOrb } from './scroll-orb.js';
 import { initParallax } from './parallax.js';
 
+export function setupLinkTransitions() {
+  const reset = () => document.body.classList.remove('page-exit');
+
+  const handleClick = (e) => {
+    if (
+      e.defaultPrevented ||
+      e.button !== 0 ||
+      e.metaKey ||
+      e.ctrlKey ||
+      e.shiftKey ||
+      e.altKey
+    ) {
+      return;
+    }
+
+    const link = e.target.closest('a[href]');
+    if (!link) return;
+
+    const url = new URL(link.href, window.location.href);
+    if (
+      link.target === '_blank' ||
+      url.origin !== window.location.origin ||
+      (url.hash && url.pathname === window.location.pathname)
+    ) {
+      return;
+    }
+
+    e.preventDefault();
+    document.body.classList.add('page-exit');
+    const navigate = () => {
+      document.body.removeEventListener('transitionend', navigate);
+      window.location.assign(link.href);
+    };
+    document.body.addEventListener('transitionend', navigate);
+  };
+
+  document.addEventListener('click', handleClick);
+  window.addEventListener('pageshow', reset);
+  window.addEventListener('load', reset);
+
+  return () => document.removeEventListener('click', handleClick);
+}
+
 if (window.location.protocol === 'file:') {
   document.addEventListener('DOMContentLoaded', () => {
     document.body.innerHTML =
@@ -204,13 +247,5 @@ document.addEventListener('DOMContentLoaded', async () => {
   );
   lazyImages.forEach((img) => imageObserver.observe(img));
 
-  window.addEventListener('beforeunload', () => {
-    document.body.style.opacity = '0';
-  });
-
-  const resetOpacity = () => {
-    document.body.style.opacity = '1';
-  };
-  window.addEventListener('load', resetOpacity);
-  window.addEventListener('pageshow', resetOpacity);
+  setupLinkTransitions();
 });

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -17,6 +17,10 @@ body {
   transition: background 0.3s ease, color 0.3s ease, opacity 0.3s ease;
 }
 
+body.page-exit {
+  opacity: 0;
+}
+
 .scroll-orb {
   position: fixed;
   top: 50%;

--- a/tests/linkTransition.test.js
+++ b/tests/linkTransition.test.js
@@ -1,0 +1,43 @@
+import { jest } from '@jest/globals';
+import { setupLinkTransitions } from '../main.js';
+
+describe('link transitions', () => {
+  test('internal link triggers fade and navigation', () => {
+    document.body.innerHTML = '<a href="/about" id="go">About</a>';
+    const cleanup = setupLinkTransitions();
+    const link = document.getElementById('go');
+
+    link.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(document.body.classList.contains('page-exit')).toBe(true);
+
+    cleanup();
+    document.body.classList.remove('page-exit');
+  });
+
+  test('external link bypasses fade', () => {
+    document.body.innerHTML = '<a href="https://example.com" id="ext">Ext</a>';
+    setupLinkTransitions();
+    const link = document.getElementById('ext');
+    const initialHref = window.location.href;
+
+    link.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(document.body.classList.contains('page-exit')).toBe(false);
+    expect(window.location.href).toBe(initialHref);
+  });
+
+  test('modifier click bypasses fade', () => {
+    document.body.innerHTML = '<a href="/blog" id="mod">Blog</a>';
+    setupLinkTransitions();
+    const link = document.getElementById('mod');
+
+    link.dispatchEvent(new MouseEvent('click', { bubbles: true, ctrlKey: true }));
+    expect(document.body.classList.contains('page-exit')).toBe(false);
+  });
+
+  test('class removed on pageshow', () => {
+    document.body.classList.add('page-exit');
+    setupLinkTransitions();
+    window.dispatchEvent(new Event('pageshow'));
+    expect(document.body.classList.contains('page-exit')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- refine link transition logic
- support modifier and middle click bypass
- ensure fade class reset on load
- extend tests for transition handler

## Testing
- `npm test`
- `npx sass src/styles/main.scss main.css`


------
https://chatgpt.com/codex/tasks/task_e_68550a9f38fc832bba16a30cc62ee2b2