### PR TITLE
Add cinematic hero animations

### DIFF
--- a/hero-animations.js
+++ b/hero-animations.js
@@ -76,6 +76,34 @@ export async function initHeroAnimations() {
     subtitleEl.textContent = '';
   }
 
+  const cinematicTl = timeline({ easing: 'easeOutCubic', duration: 800 });
+
+  cinematicTl
+    .add({
+      targets: '.hero-cinematic',
+      opacity: [0, 1],
+      scale: [0.8, 1],
+      duration: 600,
+    })
+    .add({
+      targets: '.hero-cinematic',
+      transform: [
+        'perspective(400px) rotateX(-20deg) translateZ(-80px)',
+        'perspective(1000px) rotateX(0deg) translateZ(0)',
+      ],
+      duration: 800,
+    }, 0)
+    .add({
+      targets: '.hero-shapes .shape',
+      opacity: [0, 0.6],
+      translateZ: [-80, 0],
+      delay: stagger(100),
+      easing: 'easeOutCubic',
+      duration: 700,
+    });
+
+  await cinematicTl.finished;
+
   const tl = timeline({ easing: 'easeOutCubic', duration: 700 });
 
   tl.add({
@@ -100,14 +128,6 @@ export async function initHeroAnimations() {
     easing: 'easeOutBack',
   });
 
-  animate('.hero-shapes .shape', {
-    opacity: [0, 0.6],
-    scale: [0.8, 1],
-    rotate: [-90, 0],
-    delay: stagger(150, { start: 500 }),
-    duration: 1000,
-    easing: 'easeOutBack',
-  });
 
   animate('.hero-shapes .shape', {
     translateX: [0, 40],

--- a/index.html
+++ b/index.html
@@ -50,7 +50,8 @@
   </nav>
 
   <section id="home" class="hero">
-    <div class="hero-content">
+    <div class="hero-cinematic">
+      <div class="hero-content">
       <h1 class="hero-title">Advanced Security Solutions</h1>
       <p class="hero-subtitle">Your trusted partner for cutting‑edge cyber defense</p>
       <div class="hero-buttons">
@@ -58,17 +59,18 @@
         <button class="btn btn-secondary">Learn More</button>
       </div>
     </div>
-    <div class="hero-animation">
-      <div class="shield-animation">
-        <i class="fas fa-shield-alt">&#8203;</i>
+      <div class="hero-animation">
+        <div class="shield-animation">
+          <i class="fas fa-shield-alt">&#8203;</i>
+        </div>
       </div>
-    </div>
-    <div class="hero-shapes">
-      <span class="shape shape-1"></span>
-      <span class="shape shape-2"></span>
-      <span class="shape shape-3"></span>
-      <span class="shape shape-4"></span>
-      <span class="shape shape-5"></span>
+      <div class="hero-shapes">
+        <span class="shape shape-1"></span>
+        <span class="shape shape-2"></span>
+        <span class="shape shape-3"></span>
+        <span class="shape shape-4"></span>
+        <span class="shape shape-5"></span>
+      </div>
     </div>
   </section>
 

--- a/main.css
+++ b/main.css
@@ -219,6 +219,12 @@ section {
   background-size: cover;
 }
 
+.hero-cinematic {
+  perspective: 1000px;
+  backface-visibility: hidden;
+  transform-style: preserve-3d;
+}
+
 .hero-content {
   max-width: 1200px;
   margin: 0 auto;
@@ -1248,6 +1254,11 @@ body.dark-mode .search-box {
   .shield-animation {
     animation: none !important;
     transition: none !important;
+  }
+  .hero-cinematic {
+    perspective: none !important;
+    backface-visibility: visible !important;
+    transform: none !important;
   }
 }
 /* Responsive improvements */

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -160,6 +160,12 @@ section {
   background-size: cover;
 }
 
+.hero-cinematic {
+  perspective: 1000px;
+  backface-visibility: hidden;
+  transform-style: preserve-3d;
+}
+
 .hero-content {
   max-width: 1200px;
   margin: 0 auto;
@@ -1217,6 +1223,11 @@ body.dark-mode .search-box {
   .shield-animation {
     animation: none !important;
     transition: none !important;
+  }
+  .hero-cinematic {
+    perspective: none !important;
+    backface-visibility: visible !important;
+    transform: none !important;
   }
 }
 

--- a/tests/heroAnimations.test.js
+++ b/tests/heroAnimations.test.js
@@ -1,8 +1,8 @@
 import { jest } from '@jest/globals';
-import { typeSubtitle } from '../hero-animations.js';
 
 describe('typeSubtitle', () => {
   test('gradually inserts characters', async () => {
+    const { typeSubtitle } = await import('../hero-animations.js');
     document.body.innerHTML = '<p class="hero-subtitle"></p>';
     const el = document.querySelector('.hero-subtitle');
     jest.useFakeTimers();
@@ -19,5 +19,29 @@ describe('typeSubtitle', () => {
     expect(el.textContent).toBe('Hey');
     await promise;
     jest.useRealTimers();
+  });
+});
+
+describe('initHeroAnimations', () => {
+  test('creates cinematic timeline', async () => {
+    jest.resetModules();
+    const timeline = jest.fn(() => ({ add: jest.fn().mockReturnThis(), finished: Promise.resolve() }));
+    const animate = jest.fn(() => ({ finished: Promise.resolve() }));
+    const stagger = jest.fn(() => jest.fn());
+    jest.unstable_mockModule('animejs', () => ({
+      animate,
+      stagger,
+      timeline,
+    }));
+    global.fetch = jest.fn().mockResolvedValue({ ok: true });
+    const { initHeroAnimations } = await import('../hero-animations.js');
+    document.body.innerHTML = `
+      <div class="hero-cinematic">
+        <div class="hero-shapes"><span class="shape"></span></div>
+      </div>
+      <p class="hero-subtitle">Test</p>`;
+    window.matchMedia = jest.fn().mockReturnValue({ matches: false });
+    await initHeroAnimations();
+    expect(timeline).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary
- wrap hero area with `.hero-cinematic` container
- create cinematic anime.js timeline for hero animations
- style `.hero-cinematic` with perspective and backface visibility
- disable cinematic effect when reduced motion is preferred
- test that the new timeline runs when hero animations initialize

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68550f4da7e8832b9da1f617cd92c245