### PR TITLE
Add parallax layers and section background transitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
           <i class="fas fa-shield-alt">&#8203;</i>
         </div>
       </div>
-      <div class="hero-shapes">
+      <div class="hero-shapes parallax-layer" data-speed="0.4">
         <span class="shape shape-1"></span>
         <span class="shape shape-2"></span>
         <span class="shape shape-3"></span>
@@ -75,6 +75,17 @@
   </section>
 
   <section id="features" class="features">
+    <div class="parallax-layer" data-speed="0.2" style="position:absolute;top:-50px;right:10%;width:150px;height:150px;pointer-events:none;">
+      <svg viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="50" cy="50" r="50" fill="url(#grad1)" />
+        <defs>
+          <linearGradient id="grad1" x1="0" x2="1" y1="0" y2="1">
+            <stop offset="0%" stop-color="#c4b5fd" />
+            <stop offset="100%" stop-color="#a5b4fc" />
+          </linearGradient>
+        </defs>
+      </svg>
+    </div>
     <div class="container">
       <h2 class="section-title">Our Features</h2>
       <div class="features-grid">
@@ -111,6 +122,17 @@
   </section>
 
   <section id="services" class="services">
+    <div class="parallax-layer" data-speed="0.6" style="position:absolute;bottom:-60px;left:5%;width:200px;height:200px;pointer-events:none;">
+      <svg viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <rect width="120" height="120" rx="20" fill="url(#grad2)" />
+        <defs>
+          <linearGradient id="grad2" x1="0" x2="1" y1="0" y2="1">
+            <stop offset="0%" stop-color="#fed7aa" />
+            <stop offset="100%" stop-color="#fdba74" />
+          </linearGradient>
+        </defs>
+      </svg>
+    </div>
     <div class="container">
       <h2 class="section-title">Security Services</h2>
       <div class="services-list">

--- a/main.css
+++ b/main.css
@@ -73,11 +73,19 @@ body {
   color: var(--text-color);
   line-height: 1.6;
   opacity: 1;
-  transition: background 0.3s ease, color 0.3s ease, opacity 0.3s ease;
+  transition: background 0.6s ease, color 0.3s ease, opacity 0.3s ease;
 }
 
 body.page-exit {
   opacity: 0;
+}
+
+body.section-features-active {
+  background: linear-gradient(135deg, #f0f9ff 0%, #e0f2fe 100%);
+}
+
+body.section-services-active {
+  background: linear-gradient(135deg, #fff7ed 0%, #ffedd5 100%);
 }
 
 .scroll-orb {
@@ -109,7 +117,8 @@ section {
   top: 0;
   width: 100%;
   background: rgba(255, 255, 255, 0.6);
-  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+          backdrop-filter: blur(20px);
   border-bottom: 1px solid rgba(255, 255, 255, 0.4);
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
   z-index: 1000;
@@ -245,7 +254,7 @@ section {
   font-size: 1.5rem;
   color: rgba(255, 255, 255, 0.9);
   margin-bottom: 2rem;
-  animation: fade-in-up 0.8s ease 0.2s both;
+  opacity: 0;
 }
 .hero-subtitle.typing::after {
   content: "";
@@ -379,6 +388,7 @@ section {
 }
 /* Features Section */
 .features {
+  position: relative;
   padding: 5rem 0;
   background: linear-gradient(180deg, var(--bg-color), var(--bg-secondary));
 }
@@ -416,7 +426,8 @@ section {
 
 .feature-card {
   background: rgba(255, 255, 255, 0.7);
-  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+          backdrop-filter: blur(10px);
   border: 1px solid rgba(255, 255, 255, 0.4);
   padding: 2rem;
   border-radius: 12px;
@@ -495,6 +506,7 @@ section {
 
 /* Services Section */
 .services {
+  position: relative;
   padding: 5rem 0;
   background: linear-gradient(180deg, var(--bg-secondary), var(--surface-color));
 }
@@ -510,7 +522,8 @@ section {
   margin-bottom: 3rem;
   padding: 2rem;
   background: rgba(255, 255, 255, 0.7);
-  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+          backdrop-filter: blur(10px);
   border: 1px solid rgba(255, 255, 255, 0.4);
   border-radius: 12px;
   box-shadow: var(--card-shadow);
@@ -999,7 +1012,8 @@ body.dark-mode .demo-card {
   border-radius: 5px;
   font-size: 1rem;
   background: rgba(255, 255, 255, 0.6);
-  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+          backdrop-filter: blur(5px);
   transition: border-color 0.3s ease;
 }
 

--- a/main.js
+++ b/main.js
@@ -51,6 +51,35 @@ export function setupLinkTransitions() {
   return () => document.removeEventListener('click', handleClick);
 }
 
+export function initSectionBackgrounds() {
+  const sectionClasses = {
+    features: 'section-features-active',
+    services: 'section-services-active',
+  };
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          Object.values(sectionClasses).forEach((cls) =>
+            document.body.classList.remove(cls),
+          );
+          const cls = sectionClasses[entry.target.id];
+          if (cls) document.body.classList.add(cls);
+        }
+      });
+    },
+    { threshold: 0.5 },
+  );
+
+  Object.keys(sectionClasses).forEach((id) => {
+    const el = document.getElementById(id);
+    if (el) observer.observe(el);
+  });
+
+  return observer;
+}
+
 if (window.location.protocol === 'file:') {
   document.addEventListener('DOMContentLoaded', () => {
     document.body.innerHTML =
@@ -64,6 +93,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   await initHeroAnimations();
   initParallax();
   initScrollOrb();
+  initSectionBackgrounds();
 
   const counters = document.querySelectorAll('.stat-number');
   const speed = 200;

--- a/parallax.js
+++ b/parallax.js
@@ -1,14 +1,27 @@
 export function initParallax() {
-  const shapes = document.querySelector('.hero-shapes');
-  if (!shapes) return;
+  const layers = Array.from(document.querySelectorAll('.parallax-layer'));
+  if (layers.length === 0) return;
+
   if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-    shapes.style.transform = 'none';
+    layers.forEach((layer) => {
+      layer.style.transform = 'none';
+    });
     return;
   }
+
+  const defaultSpeeds = [0.2, 0.4, 0.6];
   const update = () => {
-    const offset = window.scrollY * 0.3;
-    shapes.style.transform = `translateY(${offset}px)`;
+    const y = window.scrollY;
+    layers.forEach((layer, idx) => {
+      const parsed = parseFloat(layer.dataset.speed);
+      const speed = Number.isFinite(parsed)
+        ? parsed
+        : defaultSpeeds[idx % defaultSpeeds.length];
+      const offset = y * speed;
+      layer.style.transform = `translateY(${offset}px)`;
+    });
   };
+
   update();
   window.addEventListener('scroll', () => {
     requestAnimationFrame(update);

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -14,11 +14,19 @@ body {
   color: var(--text-color);
   line-height: 1.6;
   opacity: 1;
-  transition: background 0.3s ease, color 0.3s ease, opacity 0.3s ease;
+  transition: background 0.6s ease, color 0.3s ease, opacity 0.3s ease;
 }
 
 body.page-exit {
   opacity: 0;
+}
+
+body.section-features-active {
+  background: linear-gradient(135deg, #f0f9ff 0%, #e0f2fe 100%);
+}
+
+body.section-services-active {
+  background: linear-gradient(135deg, #fff7ed 0%, #ffedd5 100%);
 }
 
 .scroll-orb {
@@ -321,6 +329,7 @@ section {
 
 /* Features Section */
 .features {
+  position: relative;
   padding: 5rem 0;
   background: linear-gradient(180deg, var(--bg-color), var(--bg-secondary));
 }
@@ -445,6 +454,7 @@ section {
 
 /* Services Section */
 .services {
+  position: relative;
   padding: 5rem 0;
   background: linear-gradient(180deg, var(--bg-secondary), var(--surface-color));
 }

--- a/tests/parallax.test.js
+++ b/tests/parallax.test.js
@@ -1,27 +1,67 @@
 import { jest } from '@jest/globals';
 import { initParallax } from '../parallax.js';
+import { initSectionBackgrounds } from '../main.js';
 
 describe('initParallax', () => {
-  test('updates transform based on scroll when motion allowed', () => {
-    document.body.innerHTML = '<div class="hero-shapes"></div>';
-    Object.defineProperty(window, 'scrollY', { configurable: true, writable: true, value: 100 });
+  test('updates multiple layer transforms', () => {
+    document.body.innerHTML = `
+      <div class="parallax-layer" data-speed="0.2"></div>
+      <div class="parallax-layer" data-speed="0.4"></div>`;
+    Object.defineProperty(window, 'scrollY', {
+      configurable: true,
+      writable: true,
+      value: 100,
+    });
     window.matchMedia = jest.fn().mockReturnValue({ matches: false });
     jest.useFakeTimers();
     initParallax();
     window.dispatchEvent(new Event('scroll'));
     jest.runAllTimers();
-    const shapes = document.querySelector('.hero-shapes');
-    expect(shapes.style.transform).toBe('translateY(30px)');
+    const layers = document.querySelectorAll('.parallax-layer');
+    expect(layers[0].style.transform).toBe('translateY(20px)');
+    expect(layers[1].style.transform).toBe('translateY(40px)');
     jest.useRealTimers();
   });
 
   test('no update when prefers-reduced-motion', () => {
-    document.body.innerHTML = '<div class="hero-shapes"></div>';
+    document.body.innerHTML = '<div class="parallax-layer"></div>';
     Object.defineProperty(window, 'scrollY', { configurable: true, writable: true, value: 50 });
     window.matchMedia = jest.fn().mockReturnValue({ matches: true });
     initParallax();
     window.dispatchEvent(new Event('scroll'));
-    const shapes = document.querySelector('.hero-shapes');
-    expect(shapes.style.transform).toBe('none');
+    const layer = document.querySelector('.parallax-layer');
+    expect(layer.style.transform).toBe('none');
+  });
+
+  test('uses default speed when none specified', () => {
+    document.body.innerHTML = '<div class="parallax-layer"></div>';
+    Object.defineProperty(window, 'scrollY', { configurable: true, writable: true, value: 50 });
+    window.matchMedia = jest.fn().mockReturnValue({ matches: false });
+    jest.useFakeTimers();
+    initParallax();
+    window.dispatchEvent(new Event('scroll'));
+    jest.runAllTimers();
+    const layer = document.querySelector('.parallax-layer');
+    expect(layer.style.transform).toBe('translateY(10px)');
+    jest.useRealTimers();
+  });
+});
+
+describe('initSectionBackgrounds', () => {
+  test('body class toggles on intersection', () => {
+    document.body.innerHTML = '<section id="features"></section><section id="services"></section>';
+    const callbacks = [];
+    global.IntersectionObserver = class {
+      constructor(cb) {
+        callbacks.push(cb);
+      }
+      observe() {}
+      unobserve() {}
+    };
+    initSectionBackgrounds();
+    callbacks[0]([{ target: document.getElementById('features'), isIntersecting: true }]);
+    expect(document.body.classList.contains('section-features-active')).toBe(true);
+    callbacks[0]([{ target: document.getElementById('services'), isIntersecting: true }]);
+    expect(document.body.classList.contains('section-services-active')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- enhance parallax.js to handle multiple `.parallax-layer` elements with different speeds
- update main.js with `initSectionBackgrounds` IntersectionObserver to toggle body classes
- style section-specific background gradients and transitions
- insert decorative parallax layers in `index.html`
- adjust features/services styles for absolute layers
- expand parallax tests to cover multiple layers and section background logic
- improve parallax speed handling and tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855121c5bc8832bb8fd5083d680daf9