### PR TITLE
Fix CSP inline style violations

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -10,7 +10,7 @@
 </head>
 <body>
   <noscript>
-    <style>#preloader{display:none!important}</style>
+    <link rel="stylesheet" href="noscript.css" />
     <div class="no-js-message">This dashboard requires JavaScript to function properly.</div>
   </noscript>
   <div class="scroll-orb" aria-hidden="true"></div>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     </div>
   </div>
   <noscript>
-    <style>#preloader{display:none!important}</style>
+    <link rel="stylesheet" href="noscript.css" />
     <div class="no-js-message">This site requires JavaScript to function properly.</div>
   </noscript>
   <div class="scroll-orb" aria-hidden="true"></div>
@@ -80,7 +80,7 @@
   </section>
 
   <section id="features" class="features">
-    <div class="parallax-layer" data-speed="0.2" style="position:absolute;top:-50px;right:10%;width:150px;height:150px;pointer-events:none;">
+    <div class="parallax-layer features-deco" data-speed="0.2">
       <svg viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
         <circle cx="50" cy="50" r="50" fill="url(#grad1)" />
         <defs>
@@ -127,7 +127,7 @@
   </section>
 
   <section id="services" class="services">
-    <div class="parallax-layer" data-speed="0.6" style="position:absolute;bottom:-60px;left:5%;width:200px;height:200px;pointer-events:none;">
+    <div class="parallax-layer services-deco" data-speed="0.6">
       <svg viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
         <rect width="120" height="120" rx="20" fill="url(#grad2)" />
         <defs>

--- a/main.css
+++ b/main.css
@@ -107,6 +107,30 @@ body.section-services-active {
   overflow: hidden;
 }
 
+/* Decorative parallax elements */
+.features-deco {
+  position: absolute;
+  top: -50px;
+  right: 10%;
+  width: 150px;
+  height: 150px;
+  pointer-events: none;
+}
+
+.services-deco {
+  position: absolute;
+  bottom: -60px;
+  left: 5%;
+  width: 200px;
+  height: 200px;
+  pointer-events: none;
+}
+
+.file-protocol-message {
+  padding: 2rem;
+  font-size: 1.2rem;
+}
+
 section {
   scroll-margin-top: 90px;
 }
@@ -117,7 +141,8 @@ section {
   top: 0;
   width: 100%;
   background: rgba(255, 255, 255, 0.6);
-  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+          backdrop-filter: blur(20px);
   border-bottom: 1px solid rgba(255, 255, 255, 0.4);
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
   z-index: 1000;
@@ -425,7 +450,8 @@ section {
 
 .feature-card {
   background: rgba(255, 255, 255, 0.7);
-  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+          backdrop-filter: blur(10px);
   border: 1px solid rgba(255, 255, 255, 0.4);
   padding: 2rem;
   border-radius: 12px;
@@ -521,7 +547,8 @@ section {
   margin-bottom: 3rem;
   padding: 2rem;
   background: rgba(255, 255, 255, 0.7);
-  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+          backdrop-filter: blur(10px);
   border: 1px solid rgba(255, 255, 255, 0.4);
   border-radius: 12px;
   box-shadow: var(--card-shadow);
@@ -830,6 +857,7 @@ body.dark-mode .scroll-orb {
   height: 100%;
   background: var(--bg-color);
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   z-index: 9999;
@@ -842,20 +870,44 @@ body.dark-mode .scroll-orb {
   pointer-events: none;
 }
 
-.loading-spinner {
-  width: 50px;
-  height: 50px;
-  border: 3px solid rgba(0, 0, 0, 0.1);
-  border-top-color: var(--accent-color);
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
+.preloader-shield {
+  width: 64px;
+  height: 64px;
+  fill: var(--primary-color);
+  filter: drop-shadow(var(--shadow-glow));
 }
 
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
+.preloader-progress {
+  width: 80%;
+  max-width: 300px;
+  height: 8px;
+  margin-top: 1.5rem;
+  border-radius: var(--radius-md);
+  background: var(--border-light);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
 }
+
+.preloader-progress .progress-bar {
+  width: 0;
+  height: 100%;
+  background: var(--primary-color);
+  border-radius: inherit;
+  transition: width 0.3s ease;
+}
+
+body.dark-mode #preloader .preloader-shield {
+  fill: var(--primary-light);
+}
+
+body.dark-mode #preloader .preloader-progress {
+  background: var(--border-color);
+}
+
+body.dark-mode #preloader .progress-bar {
+  background: var(--accent-color);
+}
+
 /* Scroll to Top Button */
 .scroll-top {
   position: fixed;
@@ -1010,7 +1062,8 @@ body.dark-mode .demo-card {
   border-radius: 5px;
   font-size: 1rem;
   background: rgba(255, 255, 255, 0.6);
-  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+          backdrop-filter: blur(5px);
   transition: border-color 0.3s ease;
 }
 
@@ -1307,3 +1360,4 @@ body.dark-mode .search-box {
     color: #000;
   }
 }
+/*# sourceMappingURL=main.css.map */

--- a/main.js
+++ b/main.js
@@ -89,7 +89,7 @@ export function initSectionBackgrounds() {
 if (window.location.protocol === 'file:') {
   document.addEventListener('DOMContentLoaded', () => {
     document.body.innerHTML =
-      '<p style="padding:2rem;font-size:1.2rem">Please run this site via a local server (e.g., <code>python security.py</code>) to avoid CORS issues.</p>';
+      '<p class="file-protocol-message">Please run this site via a local server (e.g., <code>python security.py</code>) to avoid CORS issues.</p>';
   });
 }
 

--- a/noscript.css
+++ b/noscript.css
@@ -1,0 +1,2 @@
+#preloader{display:none!important}
+.no-js-message{padding:1rem;text-align:center;background:#ffdddd;color:#000;font-family:Arial, sans-serif}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -48,6 +48,30 @@ body.section-services-active {
   overflow: hidden;
 }
 
+/* Decorative parallax elements */
+.features-deco {
+  position: absolute;
+  top: -50px;
+  right: 10%;
+  width: 150px;
+  height: 150px;
+  pointer-events: none;
+}
+
+.services-deco {
+  position: absolute;
+  bottom: -60px;
+  left: 5%;
+  width: 200px;
+  height: 200px;
+  pointer-events: none;
+}
+
+.file-protocol-message {
+  padding: 2rem;
+  font-size: 1.2rem;
+}
+
 section {
   scroll-margin-top: 90px;
 }


### PR DESCRIPTION
## Summary
- avoid inline styles by adding noscript.css for JS-disabled styling
- add classes for decorative parallax layers
- move file-protocol message styling to CSS
- recompile main stylesheet

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685519456c80832ba0457b9d0095cd5a