### PR TITLE
Fix anime import in preloader

### DIFF
--- a/preloader.js
+++ b/preloader.js
@@ -1,16 +1,16 @@
 export async function initPreloader() {
-  let anime;
+  let animate;
   if (typeof process !== 'undefined' && process.env.JEST_WORKER_ID) {
-    anime = () => {};
+    animate = () => {};
   } else {
     try {
       const mod = await import('animejs');
-      anime = mod.default;
+      animate = mod.animate || mod.default;
     } catch {
       const fallback = await import(
         'https://cdn.jsdelivr.net/npm/animejs@4.0.2/lib/anime.esm.js'
       );
-      anime = fallback.default;
+      animate = fallback.animate || fallback.default;
     }
   }
   const preloader = document.getElementById('preloader');
@@ -19,7 +19,7 @@ export async function initPreloader() {
   const shield = preloader.querySelector('.preloader-shield');
   const progressBar = preloader.querySelector('.progress-bar');
 
-  anime({
+  animate({
     targets: shield,
     rotate: '360deg',
     duration: 1000,

--- a/tests/preloader.test.js
+++ b/tests/preloader.test.js
@@ -3,7 +3,7 @@ import { jest } from '@jest/globals';
 describe('initPreloader', () => {
   test('removes preloader after images load', async () => {
     jest.resetModules();
-    jest.unstable_mockModule('animejs', () => ({ default: jest.fn() }));
+    jest.unstable_mockModule('animejs', () => ({ animate: jest.fn() }));
     const { initPreloader } = await import('../preloader.js');
 
     document.body.innerHTML = `


### PR DESCRIPTION
## Summary
- use `animate` export from animejs rather than deprecated default
- adjust preloader test mock

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68551b6460ac832b934f76fcd1ece543