### PR TITLE
Fix preloader animation load

### DIFF
--- a/anime-loader.js
+++ b/anime-loader.js
@@ -1,0 +1,44 @@
+let animeModule;
+const CDN_URL =
+  'https://cdn.jsdelivr.net/npm/animejs@4.0.2/lib/anime.esm.min.js';
+const EXPECTED_CDN_HASH =
+  'e8eb5b27f49049d82da9cebd01d3809ea5141f6d524f2960824345e0ca45f237';
+
+async function loadFromCDN() {
+  try {
+    const res = await fetch(CDN_URL);
+    const text = await res.text();
+    const encoder = new TextEncoder();
+    const data = encoder.encode(text);
+    const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    const hashHex = hashArray
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+    if (hashHex !== EXPECTED_CDN_HASH) {
+      console.warn('Anime.js CDN hash mismatch. Animations disabled.');
+      return null;
+    }
+    const blob = new Blob([text], { type: 'application/javascript' });
+    const blobURL = URL.createObjectURL(blob);
+    const mod = await import(blobURL);
+    URL.revokeObjectURL(blobURL);
+    return mod;
+  } catch (err) {
+    console.error('Failed to load Anime.js from CDN', err);
+    return null;
+  }
+}
+
+export async function getAnime() {
+  if (animeModule !== undefined) return animeModule;
+
+  try {
+    animeModule = await import('animejs');
+  } catch (err) {
+    console.warn('Local Anime.js not found, falling back to CDN...', err);
+    animeModule = await loadFromCDN();
+  }
+
+  return animeModule;
+}

--- a/hero-animations.js
+++ b/hero-animations.js
@@ -1,58 +1,18 @@
-// Import Anime.js from the local node_modules directory so the script works
-// when served by a simple HTTP server without a bundler.
+import { getAnime } from './anime-loader.js';
 let animeModule;
 
 export async function typeSubtitle(element, text, interval = 50) {
   element.textContent = '';
   element.classList.add('typing');
   for (const char of text) {
-    // eslint-disable-next-line no-await-in-loop
     await new Promise((r) => setTimeout(r, interval));
     element.textContent += char;
   }
   element.classList.remove('typing');
 }
 
-const CDN_URL =
-  'https://cdn.jsdelivr.net/npm/animejs@4.0.2/lib/anime.esm.min.js';
-// sha256 hash of the file at CDN_URL (hex encoded)
-const EXPECTED_CDN_HASH =
-  'e8eb5b27f49049d82da9cebd01d3809ea5141f6d524f2960824345e0ca45f237';
-
 async function loadAnime() {
-  try {
-    const res = await fetch('./node_modules/animejs/lib/anime.esm.js', { method: 'HEAD' });
-    if (res.ok) {
-      animeModule = await import('animejs');
-      return;
-    }
-    throw new Error('local file missing');
-  } catch (err) {
-    console.warn('Local Anime.js not found, loading from CDN...', err);
-    try {
-      const res = await fetch(CDN_URL);
-      const text = await res.text();
-      const encoder = new TextEncoder();
-      const data = encoder.encode(text);
-      const hashBuffer = await crypto.subtle.digest('SHA-256', data);
-      const hashArray = Array.from(new Uint8Array(hashBuffer));
-      const hashHex = hashArray
-        .map((b) => b.toString(16).padStart(2, '0'))
-        .join('');
-      if (hashHex !== EXPECTED_CDN_HASH) {
-        console.warn('Anime.js CDN hash mismatch. Animations disabled.');
-        animeModule = null;
-        return;
-      }
-      const blob = new Blob([text], { type: 'application/javascript' });
-      const blobURL = URL.createObjectURL(blob);
-      animeModule = await import(blobURL);
-      URL.revokeObjectURL(blobURL);
-    } catch (cdnErr) {
-      console.error('Failed to load Anime.js from CDN', cdnErr);
-      animeModule = null;
-    }
-  }
+  animeModule = await getAnime();
 }
 
 export async function initHeroAnimations() {

--- a/preloader.js
+++ b/preloader.js
@@ -1,17 +1,12 @@
+import { getAnime } from './anime-loader.js';
+
 export async function initPreloader() {
   let animate;
   if (typeof process !== 'undefined' && process.env.JEST_WORKER_ID) {
     animate = () => {};
   } else {
-    try {
-      const mod = await import('animejs');
-      animate = mod.animate || mod.default;
-    } catch {
-      const fallback = await import(
-        'https://cdn.jsdelivr.net/npm/animejs@4.0.2/lib/anime.esm.js'
-      );
-      animate = fallback.animate || fallback.default;
-    }
+    const mod = await getAnime();
+    animate = mod?.animate || mod?.default || (() => {});
   }
   const preloader = document.getElementById('preloader');
   if (!preloader) return Promise.resolve();
@@ -19,8 +14,7 @@ export async function initPreloader() {
   const shield = preloader.querySelector('.preloader-shield');
   const progressBar = preloader.querySelector('.progress-bar');
 
-  animate({
-    targets: shield,
+  animate(shield, {
     rotate: '360deg',
     duration: 1000,
     easing: 'linear',


### PR DESCRIPTION
## Summary
- create a shared `anime-loader` module
- use the new loader in hero and preloader scripts
- fix preloader call to `animate` API
- simplify loader and improve CDN fallback

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68551ca96460832ba97a0ac8a591cca4