### PR TITLE
Remove unused alias from Vite config

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite';
-import path from 'path';
+// This project previously aliased '@' to 'src' but no files
+// use that path prefix, so the alias block was removed.
 
 export default defineConfig({
   css: {
@@ -13,9 +14,4 @@ export default defineConfig({
     outDir: 'dist',
   },
   base: './',
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-    },
-  },
 });


### PR DESCRIPTION
## Summary
- clarify that the `resolve.alias` section was removed because no `@/` imports exist

## Testing
- `npm ci --ignore-scripts`
- `npm run lint`
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6855274a7cb8832b907c8522d14a83fc