### PR TITLE
Fix anime.js loader and hero animation

### DIFF
--- a/hero-animations.js
+++ b/hero-animations.js
@@ -28,7 +28,7 @@ export async function initHeroAnimations() {
     return;
   }
 
-  const { animate, stagger, timeline } = animeModule;
+  const { animate, stagger, createTimeline } = animeModule;
 
   const subtitleEl = document.querySelector('.hero-subtitle');
   const subtitleText = subtitleEl?.textContent || '';
@@ -36,7 +36,7 @@ export async function initHeroAnimations() {
     subtitleEl.textContent = '';
   }
 
-  const cinematicTl = timeline({ easing: 'easeOutCubic', duration: 800 });
+  const cinematicTl = createTimeline({ easing: 'easeOutCubic', duration: 800 });
 
   cinematicTl
     .add({
@@ -64,7 +64,7 @@ export async function initHeroAnimations() {
 
   await cinematicTl.finished;
 
-  const tl = timeline({ easing: 'easeOutCubic', duration: 700 });
+  const tl = createTimeline({ easing: 'easeOutCubic', duration: 700 });
 
   tl.add({
     targets: '.hero-title',

--- a/importmap.json
+++ b/importmap.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "animejs": "./node_modules/animejs/lib/anime.esm.js",
+    "animejs": "./anime.bundle.mjs",
     "dompurify": "./node_modules/dompurify/dist/purify.es.mjs",
     "chart.js/auto": "./node_modules/chart.js/auto/auto.js"
   }

--- a/tests/heroAnimations.test.js
+++ b/tests/heroAnimations.test.js
@@ -25,13 +25,13 @@ describe('typeSubtitle', () => {
 describe('initHeroAnimations', () => {
   test('creates cinematic timeline', async () => {
     jest.resetModules();
-    const timeline = jest.fn(() => ({ add: jest.fn().mockReturnThis(), finished: Promise.resolve() }));
+    const createTimeline = jest.fn(() => ({ add: jest.fn().mockReturnThis(), finished: Promise.resolve() }));
     const animate = jest.fn(() => ({ finished: Promise.resolve() }));
     const stagger = jest.fn(() => jest.fn());
     jest.unstable_mockModule('animejs', () => ({
       animate,
       stagger,
-      timeline,
+      createTimeline,
     }));
     global.fetch = jest.fn().mockResolvedValue({ ok: true });
     const { initHeroAnimations } = await import('../hero-animations.js');
@@ -42,6 +42,6 @@ describe('initHeroAnimations', () => {
       <p class="hero-subtitle">Test</p>`;
     window.matchMedia = jest.fn().mockReturnValue({ matches: false });
     await initHeroAnimations();
-    expect(timeline).toHaveBeenCalledTimes(2);
+    expect(createTimeline).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary
- load Anime.js from bundled copy using importmap
- adjust hero animations to use `createTimeline`
- update hero animation tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68552b93b6ac832b99b7ff863070f5a4