### PR TITLE
Add search overlay and scroll top button Jest tests

### DIFF
--- a/main.js
+++ b/main.js
@@ -15,6 +15,7 @@ import { initHeroAnimations } from './hero-animations.js';
 import { initScrollOrb } from './scroll-orb.js';
 import { initParallax } from './parallax.js';
 import { initPreloader } from './preloader.js';
+import { initScrollTopButton } from './scroll-top.js';
 
 export function setupLinkTransitions() {
   const reset = () => document.body.classList.remove('page-exit');
@@ -166,22 +167,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
   });
 
-  const scrollTopBtn = document.createElement('button');
-  scrollTopBtn.className = 'scroll-top';
-  scrollTopBtn.innerHTML = '<i class="fas fa-arrow-up"></i>';
-  document.body.appendChild(scrollTopBtn);
-
-  window.addEventListener('scroll', () => {
-    if (window.scrollY > 500) {
-      scrollTopBtn.classList.add('active');
-    } else {
-      scrollTopBtn.classList.remove('active');
-    }
-  });
-
-  scrollTopBtn.addEventListener('click', () => {
-    window.scrollTo({ top: 0, behavior: 'smooth' });
-  });
+  initScrollTopButton();
 
 
   const notifications = new NotificationSystem();

--- a/scroll-top.js
+++ b/scroll-top.js
@@ -1,0 +1,20 @@
+export function initScrollTopButton() {
+  const scrollTopBtn = document.createElement('button');
+  scrollTopBtn.className = 'scroll-top';
+  scrollTopBtn.innerHTML = '<i class="fas fa-arrow-up"></i>';
+  document.body.appendChild(scrollTopBtn);
+
+  window.addEventListener('scroll', () => {
+    if (window.scrollY > 500) {
+      scrollTopBtn.classList.add('active');
+    } else {
+      scrollTopBtn.classList.remove('active');
+    }
+  });
+
+  scrollTopBtn.addEventListener('click', () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  });
+
+  return scrollTopBtn;
+}

--- a/tests/scrollTopButton.test.js
+++ b/tests/scrollTopButton.test.js
@@ -1,0 +1,20 @@
+import { jest } from '@jest/globals';
+import { initScrollTopButton } from '../scroll-top.js';
+
+describe('initScrollTopButton', () => {
+  test('button appears after scrolling and scrolls to top on click', () => {
+    document.body.innerHTML = '';
+    Object.defineProperty(window, 'scrollY', { configurable: true, writable: true, value: 0 });
+    const btn = initScrollTopButton();
+    expect(document.querySelector('.scroll-top')).toBe(btn);
+    expect(btn.classList.contains('active')).toBe(false);
+
+    window.scrollY = 600;
+    window.dispatchEvent(new Event('scroll'));
+    expect(btn.classList.contains('active')).toBe(true);
+
+    const spy = jest.spyOn(window, 'scrollTo').mockImplementation(() => {});
+    btn.click();
+    expect(spy).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+  });
+});

--- a/tests/searchOverlay.test.js
+++ b/tests/searchOverlay.test.js
@@ -1,0 +1,52 @@
+import { jest } from '@jest/globals';
+import { initSearch } from '../search.js';
+
+describe('search overlay keyboard and mouse interactions', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <button class="search-toggle"></button>
+      <div id="searchOverlay" class="search-overlay" aria-hidden="true">
+        <div class="search-box">
+          <button class="search-close"></button>
+          <input id="searchInput" />
+          <ul id="searchResults"></ul>
+        </div>
+      </div>
+      <section id="sec1"><h2>First Item</h2></section>
+      <section id="sec2"><h2>Second Feature</h2></section>
+    `;
+    const navMenu = document.createElement('div');
+    initSearch(navMenu);
+  });
+
+  test('opens with Ctrl+K and closes with Escape', () => {
+    const overlay = document.getElementById('searchOverlay');
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true }));
+    expect(overlay.classList.contains('active')).toBe(true);
+    expect(overlay.getAttribute('aria-hidden')).toBe('false');
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(overlay.classList.contains('active')).toBe(false);
+    expect(overlay.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  test('clicking overlay backdrop closes it', () => {
+    const overlay = document.getElementById('searchOverlay');
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true }));
+    overlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(overlay.classList.contains('active')).toBe(false);
+  });
+
+  test('typing shows results and clicking one closes overlay', () => {
+    const overlay = document.getElementById('searchOverlay');
+    const input = document.getElementById('searchInput');
+    const results = document.getElementById('searchResults');
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true }));
+    input.value = 'second';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    const link = results.querySelector('a');
+    expect(link).not.toBeNull();
+    link.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(overlay.classList.contains('active')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add `initScrollTopButton` module for scroll-top functionality
- invoke `initScrollTopButton` from `main.js`
- add keyboard/mouse tests for search overlay
- add scroll top button test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68553454a430832ba1dcd4fd3d606bfb