### PR TITLE
Add service worker caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,14 @@ Run `npm run update-chart` anytime you want to refresh the bundled file with the
 
 Run `npm run update-anime` to refresh the bundled Anime.js file used as a fallback by the hero animations. Pass a version number to retrieve that release, e.g. `npm run update-anime 4.0.2`. The script downloads the chosen version from jsDelivr and writes it to `anime.bundle.mjs` and `public/anime.bundle.mjs`.
 
+## Updating the service worker
+
+The service worker defined in `service-worker.js` caches core assets like `main.css`,
+`main.js`, icon fonts, and the bundled modules. Whenever you add new resources or
+want to bust the cache, update the `ASSETS` list in the file and bump the
+`CACHE_NAME` version. Reload the page after rebuilding to ensure clients receive
+the latest service worker.
+
 
 
 ## Security auditing

--- a/main.js
+++ b/main.js
@@ -272,3 +272,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   setupLinkTransitions();
 });
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/service-worker.js');
+  });
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,44 @@
+const CACHE_NAME = 'sg-cache-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/main.css',
+  '/main.js',
+  '/anime.bundle.mjs',
+  '/dashboard/chart.bundle.mjs',
+  '/public/anime.bundle.mjs',
+  '/public/dashboard/chart.bundle.mjs',
+  '/node_modules/@fontsource/poppins/files/poppins-devanagari-400-normal.woff2',
+  '/node_modules/@fontsource/poppins/files/poppins-latin-ext-400-normal.woff2',
+  '/node_modules/@fontsource/poppins/files/poppins-latin-400-normal.woff2',
+  '/node_modules/@fortawesome/fontawesome-free/webfonts/fa-v4compatibility.woff2',
+  '/node_modules/@fortawesome/fontawesome-free/webfonts/fa-solid-900.woff2',
+  '/node_modules/@fortawesome/fontawesome-free/webfonts/fa-regular-400.woff2',
+  '/node_modules/@fortawesome/fontawesome-free/webfonts/fa-brands-400.woff2'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => {
+      return Promise.all(
+        keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k))
+      );
+    })
+  );
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+  const url = new URL(event.request.url);
+  if (url.origin !== location.origin) return;
+
+  event.respondWith(
+    caches.match(event.request).then(res => res || fetch(event.request))
+  );
+});

--- a/tests/searchOverlay.test.js
+++ b/tests/searchOverlay.test.js
@@ -1,4 +1,3 @@
-import { jest } from '@jest/globals';
 import { initSearch } from '../search.js';
 
 describe('search overlay keyboard and mouse interactions', () => {


### PR DESCRIPTION
## Summary
- implement a simple service worker that caches main assets and fonts
- register the service worker from `main.js`
- document how to update the service worker
- fix lint warning in tests

## Testing
- `npm test`
- `npm run lint`
- `npm run audit`

------
https://chatgpt.com/codex/tasks/task_e_68553a7a480c832ba6152512a1642253