### PR TITLE
Add dynamic progress text to preloader

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     </svg>
     <div class="preloader-progress">
       <div class="progress-bar" role="progressbar" aria-label="Page loading" aria-valuemin="0" aria-valuemax="100"></div>
+      <span class="progress-text" aria-live="polite"></span>
     </div>
   </div>
   <noscript>

--- a/main.css
+++ b/main.css
@@ -898,6 +898,7 @@ body.dark-mode .scroll-orb {
 }
 
 .preloader-progress {
+  position: relative;
   width: 80%;
   max-width: 300px;
   height: 8px;
@@ -914,6 +915,14 @@ body.dark-mode .scroll-orb {
   background: var(--primary-color);
   border-radius: inherit;
   transition: width 0.3s ease;
+}
+
+.preloader-progress .progress-text {
+  position: absolute;
+  top: -1.5rem;
+  right: 0;
+  font-size: 0.75rem;
+  color: var(--text-color);
 }
 
 body.dark-mode #preloader .preloader-shield {

--- a/preloader.js
+++ b/preloader.js
@@ -8,9 +8,11 @@ export async function initPreloader() {
 
   const shield = preloader.querySelector('.preloader-shield');
   const progressBar = preloader.querySelector('.progress-bar');
+  const progressText = preloader.querySelector('.progress-text');
 
   document.body.setAttribute('aria-busy', 'true');
   progressBar.setAttribute('aria-valuenow', '0');
+  if (progressText) progressText.textContent = '0%';
 
   const mod = await getAnime();
   animate = mod?.animate || mod?.default || (() => {});
@@ -53,6 +55,7 @@ export async function initPreloader() {
       clearInterval(timer);
       progressBar.style.width = '100%';
       progressBar.removeAttribute('aria-valuenow');
+      if (progressText) progressText.textContent = '100%';
       document.body.removeAttribute('aria-busy');
       tracked.forEach(({ img, handler }) => {
         img.removeEventListener('load', handler);
@@ -78,6 +81,7 @@ export async function initPreloader() {
     }
     progressBar.style.width = `${progress}%`;
     progressBar.setAttribute('aria-valuenow', String(Math.round(progress)));
+    if (progressText) progressText.textContent = `${Math.round(progress)}%`;
     if (progress >= 100) {
       finish();
     }
@@ -90,6 +94,7 @@ export async function initPreloader() {
         if (loaded === total) {
           progressBar.style.width = '100%';
           progressBar.setAttribute('aria-valuenow', '100');
+          if (progressText) progressText.textContent = '100%';
         }
       };
       tracked.push({ img, handler });

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -869,6 +869,7 @@ body.dark-mode .scroll-orb {
 }
 
 .preloader-progress {
+  position: relative;
   width: 80%;
   max-width: 300px;
   height: 8px;
@@ -885,6 +886,14 @@ body.dark-mode .scroll-orb {
   background: var(--primary-color);
   border-radius: inherit;
   transition: width 0.3s ease;
+}
+
+.preloader-progress .progress-text {
+  position: absolute;
+  top: -1.5rem;
+  right: 0;
+  font-size: 0.75rem;
+  color: var(--text-color);
 }
 
 body.dark-mode #preloader .preloader-shield {

--- a/tests/preloader.test.js
+++ b/tests/preloader.test.js
@@ -12,7 +12,10 @@ describe('initPreloader', () => {
     document.body.innerHTML = `
       <div id="preloader" aria-hidden="true">
         <svg class="preloader-shield"></svg>
-        <div class="preloader-progress"><div class="progress-bar"></div></div>
+        <div class="preloader-progress">
+          <div class="progress-bar"></div>
+          <span class="progress-text" aria-live="polite"></span>
+        </div>
       </div>`;
 
     const img1 = document.createElement('img');
@@ -29,12 +32,22 @@ describe('initPreloader', () => {
     jest.useFakeTimers();
     initPreloader();
     await Promise.resolve();
-    jest.advanceTimersByTime(3000);
+    const progressBar = document.querySelector('.progress-bar');
+    const progressText = document.querySelector('.progress-text');
+
+    jest.advanceTimersByTime(1500);
+    expect(progressText.textContent).toBe(
+      `${progressBar.getAttribute('aria-valuenow')}%`,
+    );
+
+    jest.advanceTimersByTime(1500);
 
     expect(addSpy1).toHaveBeenCalledWith('load', expect.any(Function));
     expect(addSpy2).toHaveBeenCalledWith('load', expect.any(Function));
     expect(removeSpy1).toHaveBeenCalledTimes(2);
     expect(removeSpy2).toHaveBeenCalledTimes(2);
+
+    expect(progressText.textContent).toBe('100%');
 
     expect(animate).toHaveBeenCalled();
     const opts = animate.mock.calls[0][1];


### PR DESCRIPTION
## Summary
- show progress percentage text in the preloader
- keep the text in sync with the aria-valuenow attribute
- position progress text above the loading bar
- test that text updates correctly

## Testing
- `npm ci --no-audit --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685542291234832baa6b218f0a0b782d