### PR TITLE
Add prefers-reduced-motion handling

### DIFF
--- a/main.css
+++ b/main.css
@@ -1351,6 +1351,14 @@ body.dark-mode .search-box {
   .preloader-shield {
     animation: none !important;
   }
+  .preloader-progress .progress-bar {
+    transition: none !important;
+  }
+  #preloader,
+  #preloader.fade-out {
+    animation: none !important;
+    transition: none !important;
+  }
   .hero-cinematic {
     perspective: none !important;
     backface-visibility: visible !important;
@@ -1392,5 +1400,4 @@ body.dark-mode .search-box {
     color: #000;
   }
 }
-
 /*# sourceMappingURL=main.css.map */


### PR DESCRIPTION
## Summary
- skip Anime.js when `prefers-reduced-motion` is enabled
- instantly show the preloader progress bar in reduced motion mode
- disable CSS animations for the preloader when motion is reduced
- test preloader behaviour under reduced motion

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68554311fa24832bbea61ca0a47196f0