### PR TITLE
Add Anime.js fallback

### DIFF
--- a/hero-animations.js
+++ b/hero-animations.js
@@ -22,19 +22,13 @@ export async function initHeroAnimations() {
     await loadAnime();
   }
 
-  if (!animeModule) {
-    return;
-  }
-
-  const { animate, stagger, createTimeline } = animeModule;
-
   const subtitleEl = document.querySelector('.hero-subtitle');
   const subtitleText = subtitleEl?.textContent || '';
   if (subtitleEl) {
     subtitleEl.textContent = '';
   }
 
-  if (reduceMotion) {
+  if (reduceMotion || !animeModule) {
     document
       .querySelectorAll(
         '.hero-cinematic, .hero-title, .hero-buttons .btn, .shield-animation'
@@ -53,6 +47,8 @@ export async function initHeroAnimations() {
     }
     return;
   }
+
+  const { animate, stagger, createTimeline } = animeModule;
 
   const introTl = createTimeline({ easing: 'easeOutExpo', duration: 800 });
 

--- a/tests/heroAnimations.test.js
+++ b/tests/heroAnimations.test.js
@@ -110,3 +110,23 @@ describe('initHeroAnimations reduced motion', () => {
     ).toBe('none');
   });
 });
+
+describe('initHeroAnimations fallback', () => {
+  test('skips animations when Anime.js fails to load', async () => {
+    jest.resetModules();
+    jest.unstable_mockModule('../anime-loader.js', () => ({
+      getAnime: () => Promise.resolve(null),
+    }));
+    const { initHeroAnimations } = await import('../hero-animations.js');
+    document.body.innerHTML = `
+      <div class="hero-cinematic">
+        <div class="hero-shapes"><span class="shape"></span></div>
+      </div>
+      <p class="hero-subtitle">Test</p>`;
+    window.matchMedia = jest.fn().mockReturnValue({ matches: false });
+    await initHeroAnimations();
+    expect(document.querySelector('.hero-subtitle').textContent).toBe('Test');
+    expect(document.querySelector('.hero-cinematic').style.transform).toBe('none');
+    expect(document.querySelector('.hero-shapes .shape').style.transform).toBe('none');
+  });
+});


### PR DESCRIPTION
## Summary
- handle missing Anime.js module in hero animations
- skip preloader effects if Anime.js can't load
- fix intro timeline promise handling
- test hero animation fallback

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685557bd3020832bb57e5a5514f53488