### PR TITLE
Use import map for DOMPurify and test resolution

### DIFF
--- a/security-demo.js
+++ b/security-demo.js
@@ -1,7 +1,7 @@
 import { checkPasswordStrength } from './utils.js';
-// Import DOMPurify directly from the local node_modules directory so the module
-// resolution works even when import maps are not supported by the browser.
-import DOMPurify from './node_modules/dompurify/dist/purify.es.mjs';
+// DOMPurify is resolved via the import map so the same path works in tests,
+// development and bundled builds.
+import DOMPurify from 'dompurify';
 
 export const securityFeatures = {
   key: null,

--- a/tests/securityDemoImport.test.js
+++ b/tests/securityDemoImport.test.js
@@ -1,0 +1,26 @@
+import { jest } from '@jest/globals';
+
+const sanitize = jest.fn((s) => s);
+
+jest.unstable_mockModule('dompurify', () => ({ default: { sanitize } }));
+
+const loadModule = async () => {
+  const mod = await import('../security-demo.js');
+  return mod;
+};
+
+test('security-demo imports DOMPurify via import map', async () => {
+  document.body.innerHTML = '<footer></footer>';
+  const { setupSecurityDemo, securityFeatures } = await loadModule();
+  // Stub out crypto-dependent functions so the demo can run in tests
+  securityFeatures.init = jest.fn();
+  securityFeatures.encrypt = jest.fn(async (t) => `enc:${t}`);
+  securityFeatures.decrypt = jest.fn(async (t) => t.replace('enc:', ''));
+  await setupSecurityDemo({ show: () => {} });
+  const input = document.getElementById('encryptInput');
+  const button = document.getElementById('encryptButton');
+  input.value = 'hello';
+  button.click();
+  await new Promise((r) => setTimeout(r, 0));
+  expect(sanitize).toHaveBeenCalledWith('hello');
+});


### PR DESCRIPTION
## Summary
- refactor `security-demo.js` to import DOMPurify via the import map
- ensure DOMPurify can be mocked in tests
- verify DOMPurify import with a new Jest test

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6855636adcbc832b80db3e255cc8987a