### PR TITLE
Improve font preloading detection

### DIFF
--- a/preloader.js
+++ b/preloader.js
@@ -196,13 +196,19 @@ export async function initPreloader(options = {}) {
         const fontHandler = () => {
           loaded += 1;
           updateProgress();
-          document.fonts.removeEventListener('loadingdone', fontHandler);
-          document.fonts.removeEventListener('loadingerror', fontHandler);
+          if ('onloadingdone' in document.fonts) {
+            document.fonts.removeEventListener('loadingdone', fontHandler);
+            document.fonts.removeEventListener('loadingerror', fontHandler);
+          }
           maybeFinish();
         };
-        document.fonts.addEventListener('loadingdone', fontHandler);
-        document.fonts.addEventListener('loadingerror', fontHandler);
-        tracked.set(document.fonts, fontHandler);
+        if ('onloadingdone' in document.fonts) {
+          document.fonts.addEventListener('loadingdone', fontHandler);
+          document.fonts.addEventListener('loadingerror', fontHandler);
+          tracked.set(document.fonts, fontHandler);
+        } else if (document.fonts.ready) {
+          document.fonts.ready.then(fontHandler, fontHandler);
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- feature-detect `loadingdone` for fonts in the preloader
- fall back to `document.fonts.ready` when events aren't supported
- simulate the fallback in unit tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6855696c6de4832baf31aa172aaea70c