### PR TITLE
Skip preloader transitions with prefers-reduced-motion

### DIFF
--- a/preloader.js
+++ b/preloader.js
@@ -48,13 +48,15 @@ export async function initPreloader(options = {}) {
         loop: true,
       });
     });
-  } else {
+  } else if (!reduceMotion) {
     shield.style.opacity = '0';
     shield.style.transition = 'opacity 0.4s linear';
     requestAnimationFrame(() => {
       shield.style.opacity = '1';
     });
     progressBar.style.transition = 'none';
+  } else {
+    shield.style.opacity = '1';
   }
 
   const isPlaceholder = (img) =>

--- a/tests/preloader.test.js
+++ b/tests/preloader.test.js
@@ -110,7 +110,8 @@ describe('initPreloader', () => {
     await preloaderPromise;
 
     expect(progressText.textContent).toBe('100%');
-    expect(shield.style.transition).toBe('opacity 0.4s linear');
+    expect(shield.style.transition).toBe('');
+    expect(progressBar.style.transition).toBe('');
     expect(shield.style.opacity).toBe('1');
     expect(createTimeline).not.toHaveBeenCalled();
     expect(timeline.add).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- disable preloader shield fade when reduced motion is requested
- update reduced-motion test to ensure no transition styles are set

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68556a9b9e70832b95a2948219e69600