### PR TITLE
Improve preload logic with smarter fetching

### DIFF
--- a/tests/preloader.test.js
+++ b/tests/preloader.test.js
@@ -324,8 +324,14 @@ describe('initPreloader', () => {
     const preloadPromise = initPreloader({ timeout: 1000 });
     await Promise.resolve();
 
-    expect(fetch).toHaveBeenCalledWith(expect.stringContaining('foo.css'));
-    expect(fetch).toHaveBeenCalledWith(expect.stringContaining('bar.js'));
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('foo.css'),
+      expect.any(Object)
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('bar.js'),
+      expect.any(Object)
+    );
 
     jest.runAllTimers();
     const preloader = document.getElementById('preloader');


### PR DESCRIPTION
## Summary
- enhance `preloadResource` to skip when `fetch` is unavailable and use caching
- preload lazy image sources, track video/audio, and always fetch preload links
- adjust tests for new fetch parameters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685579f9de28832baf697643d347a421