### PR TITLE
Enhance preload behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
         <li><a href="#services">Services</a></li>
         <li><a href="#about">About</a></li>
         <li><a href="#gallery">Gallery</a></li>
-        <li><a href="dashboard.html">Dashboard</a></li>
+        <li><a href="dashboard.html" data-prefetch>Dashboard</a></li>
         <li><a href="#contact">Contact</a></li>
       </ul>
       <button class="search-toggle" aria-label="Open search" aria-haspopup="dialog" aria-controls="searchOverlay" aria-expanded="false">

--- a/preloader.js
+++ b/preloader.js
@@ -59,6 +59,14 @@ class Preloader {
     });
   }
 
+  prefetchPages() {
+    document.querySelectorAll('a[data-prefetch]').forEach((a) => {
+      if (a.href) {
+        this.preloadResource(a.href);
+      }
+    });
+  }
+
   trackElement(el, alreadyLoaded = false) {
     if (this.assets.has(el)) return;
     this.assets.add(el);
@@ -143,6 +151,9 @@ class Preloader {
       if (el.dataset && el.dataset.src && el.classList.contains('lazy-image')) {
         this.preloadResource(el.dataset.src);
       }
+      if (el.dataset && 'prefetch' in el.dataset && el.tagName === 'A' && el.href) {
+        this.preloadResource(el.href);
+      }
       if (el.hasAttribute && el.hasAttribute('href')) {
         if (el.tagName === 'LINK' && el.rel === 'preload') {
           const as = el.getAttribute('as');
@@ -185,6 +196,7 @@ class Preloader {
     this.preloadFonts().forEach((p) => this.trackPromise(p));
 
     this.prefetchLazyImages();
+    this.prefetchPages();
 
     const images = Array.from(document.images).filter((img) => !this.isPlaceholder(img));
     images.forEach((img) => this.trackElement(img, img.complete));


### PR DESCRIPTION
## Summary
- add a `prefetchPages` method to preload linked pages
- watch for `data-prefetch` links in the DOM
- prefetch dashboard page via new attribute

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685582299f28832bbe99c18cbfea110e